### PR TITLE
[Feat]: Support for CPU and Non-Tensor Data Storage of Yuanrong

### DIFF
--- a/tests/test_kv_storage_manager.py
+++ b/tests/test_kv_storage_manager.py
@@ -62,13 +62,6 @@ class Test(unittest.TestCase):
         expected_length = len(self.field_names) * len(self.global_indexes)  # 9
         self.assertEqual(len(values), expected_length)
 
-    def test_generate_values_type_check(self):
-        """Test whether _generate_values raises an exception for non-tensor inputs."""
-        bad_data = TensorDict({"text": torch.tensor([1, 2]), "label": "not_a_tensor"}, batch_size=2)
-
-        with self.assertRaises(TypeError):
-            KVStorageManager._generate_values(bad_data)
-
     def test_merge_kv_to_tensordict(self):
         """Test whether _merge_kv_to_tensordict can correctly reconstruct the TensorDict."""
         # generate values firstly

--- a/tests/test_kv_storage_manager.py
+++ b/tests/test_kv_storage_manager.py
@@ -48,7 +48,7 @@ class Test(unittest.TestCase):
 
     def test_generate_keys(self):
         """Test whether _generate_keys can generate the correct key list."""
-        keys = KVStorageManager._generate_keys(self.metadata)
+        keys = KVStorageManager._generate_keys(self.data.keys(), self.metadata.global_indexes)
         expected = ["8@label", "9@label", "10@label", "8@mask", "9@mask", "10@mask", "8@text", "9@text", "10@text"]
         self.assertEqual(keys, expected)
         self.assertEqual(len(keys), 9)  # 3 fields * 3 indexes

--- a/tests/test_storage_client_factory.py
+++ b/tests/test_storage_client_factory.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from transfer_queue.storage.clients.factory import StorageClientFactory
-from transfer_queue.storage.clients.yuanrong_client import YRStorageClient
+from transfer_queue.storage.clients.yuanrong_client import YuanrongStorageClient
 
 
 class Test(unittest.TestCase):
@@ -14,9 +14,9 @@ class Test(unittest.TestCase):
 
     @pytest.mark.skipif(find_spec("datasystem") is None, reason="datasystem is not available")
     def test_create_client(self):
-        self.assertIn("Yuanrong", StorageClientFactory._registry)
-        self.assertIs(StorageClientFactory._registry["Yuanrong"], YRStorageClient)
-        StorageClientFactory.create("Yuanrong", self.cfg)
+        self.assertIn("YuanrongStorageClient", StorageClientFactory._registry)
+        self.assertIs(StorageClientFactory._registry["YuanrongStorageClient"], YuanrongStorageClient)
+        StorageClientFactory.create("YuanrongStorageClient", self.cfg)
 
         with self.assertRaises(ValueError) as cm:
             StorageClientFactory.create("abc", self.cfg)
@@ -32,9 +32,9 @@ class Test(unittest.TestCase):
         for t in tensors:
             shapes.append(t.shape)
             dtypes.append(t.dtype)
-        client = StorageClientFactory.create("Yuanrong", self.cfg)
+        client = StorageClientFactory.create("YuanrongStorageClient", self.cfg)
 
-        empty_tensors = client._create_empty_tensorlist(shapes, dtypes)
+        empty_tensors = client._create_empty_npu_tensorlist(shapes, dtypes)
         self.assertEqual(len(tensors), len(empty_tensors))
         for t, et in zip(tensors, empty_tensors, strict=False):
             self.assertEqual(t.shape, et.shape)

--- a/transfer_queue/storage/clients/__init__.py
+++ b/transfer_queue/storage/clients/__init__.py
@@ -15,10 +15,10 @@
 # This module is currently empty but reserved for future client implementations
 from .base import TransferQueueStorageKVClient
 from .factory import StorageClientFactory
-from .yuanrong_client import YRStorageClient
+from .yuanrong_client import YuanrongStorageClient
 
 __all__ = [
     "TransferQueueStorageKVClient",
     "StorageClientFactory",
-    "YRStorageClient",
+    "YuanrongStorageClient",
 ]

--- a/transfer_queue/storage/clients/yuanrong_client.py
+++ b/transfer_queue/storage/clients/yuanrong_client.py
@@ -26,7 +26,7 @@ except ImportError:
 
 
 @StorageClientFactory.register("YuanrongStorageClient")
-class YuanrongRStorageClient(TransferQueueStorageKVClient):
+class YuanrongStorageClient(TransferQueueStorageKVClient):
     """
     Storage client for YuanRong DataSystem.
 
@@ -145,7 +145,7 @@ class YuanrongRStorageClient(TransferQueueStorageKVClient):
             npu_keys = []
             npu_dtypes = []
             npu_shapes = []
-            for shape, dtype, key in zip(shapes, dtypes, keys):
+            for shape, dtype, key in zip(shapes, dtypes, keys, strict=False):
                 if dtype is not None:
                     npu_shapes.append(shape)
                     npu_dtypes.append(dtype)
@@ -153,7 +153,8 @@ class YuanrongRStorageClient(TransferQueueStorageKVClient):
                 else:
                     cpu_keys.append(key)
 
-            # Note: _npu_ds_client.dev_mget and _cpu_ds_client.get(keys) is assumed to return values in the same order as keys
+            # Note: _npu_ds_client.dev_mget and _cpu_ds_client.get(keys) is
+            #       assumed to return values in the same order as keys
             failed_keys = []
             npu_values = []
 
@@ -161,7 +162,7 @@ class YuanrongRStorageClient(TransferQueueStorageKVClient):
                 npu_values = self._create_empty_npu_tensorlist(npu_shapes, npu_dtypes)
                 try:
                     failed_keys = self._npu_ds_client.dev_mget(npu_keys, npu_values)
-                    failed_keys = [f_key.rsplit(',', 1)[0] for f_key in failed_keys]
+                    failed_keys = [f_key.rsplit(",", 1)[0] for f_key in failed_keys]
                 except Exception:
                     failed_keys = npu_keys
                     npu_keys = []

--- a/transfer_queue/storage/clients/yuanrong_client.py
+++ b/transfer_queue/storage/clients/yuanrong_client.py
@@ -25,7 +25,7 @@ except ImportError:
     TORCH_NPU_IMPORTED = False
 
 
-@StorageClientFactory.register("Yuanrong")
+@StorageClientFactory.register("YuanrongStorageClient")
 class YuanrongRStorageClient(TransferQueueStorageKVClient):
     """
     Storage client for YuanRong DataSystem.

--- a/transfer_queue/storage/clients/yuanrong_client.py
+++ b/transfer_queue/storage/clients/yuanrong_client.py
@@ -1,3 +1,6 @@
+import logging
+import os
+import pickle
 from typing import Any
 
 import torch
@@ -6,6 +9,9 @@ from torch import Tensor
 from transfer_queue.storage.clients.base import TransferQueueStorageKVClient
 from transfer_queue.storage.clients.factory import StorageClientFactory
 
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("TQ_LOGGING_LEVEL", logging.WARNING))
+
 YUANRONG_DATASYSTEM_IMPORTED: bool = True
 TORCH_NPU_IMPORTED: bool = True
 try:
@@ -13,34 +19,59 @@ try:
 except ImportError:
     YUANRONG_DATASYSTEM_IMPORTED = False
 try:
-    import torch_npu
+    import torch_npu  # noqa: F401
 except ImportError:
     TORCH_NPU_IMPORTED = False
 
 
-# TODO: DSTensorClient.dev_mget has wrong behavior: it may require stricter environment to execute
 @StorageClientFactory.register("Yuanrong")
 class YRStorageClient(TransferQueueStorageKVClient):
     """
     Storage client for YuanRong DataSystem.
-    Communicates with the remote tensor storage service via DsTensorClient.
-    All tensors must reside on NPU device.
+
+    Supports storing both:
+    - NPU tensors via DsTensorClient (for high performance).
+    - General objects (CPU tensors, str, bool, list, etc.) via KVClient with pickle serialization.
     """
 
     def __init__(self, config: dict[str, Any]):
         if not YUANRONG_DATASYSTEM_IMPORTED:
             raise ImportError("YuanRong DataSystem not installed.")
-        if not TORCH_NPU_IMPORTED:
-            raise ImportError("Torch_npu not installed.")
 
         self.host = config.get("host")
         self.port = config.get("port")
-        self.device_id = config.get("device_id")
-        torch_npu.npu.set_device(f"npu:{self.device_id}")  # set npu_device
-        self._ds_client = datasystem.DsTensorClient(self.host, self.port, self.device_id)
-        self._ds_client.init()
+        self._npu_ds_client = None
+        self._cpu_ds_client = None
+        self.DS_CLIENT_KEYS_LIMIT = 1000
+        self.device_id = None
+        if not TORCH_NPU_IMPORTED:
+            logger.warning(
+                "'torch_npu' import failed. "
+                "This results in the inability to quickly store and retrieve tensors on the NPU side,"
+                "which may affect performance."
+            )
+        elif not torch.npu.is_available():
+            logger.warning(
+                "NPU is not available. "
+                "This results in the inability to quickly store and retrieve tensors on the NPU side, "
+                "which may affect performance."
+            )
+        else:
+            self.device_id = torch.npu.current_device()
+            self._npu_ds_client = datasystem.DsTensorClient(self.host, self.port, self.device_id)
+            self._npu_ds_client.init()
 
-    def _create_empty_tensorlist(self, shapes, dtypes):
+        self._cpu_ds_client = datasystem.KVClient(self.host, self.port)
+        self._cpu_ds_client.init()
+
+    def npu_ds_client_is_available(self):
+        return False
+        # return self._npu_ds_client is not None
+
+    def cpu_ds_client_is_available(self):
+        return self._cpu_ds_client is not None
+
+    def _create_empty_npu_tensorlist(self, shapes, dtypes):
         """
         Create a list of empty NPU tensors with given shapes and dtypes.
         Args:
@@ -49,18 +80,43 @@ class YRStorageClient(TransferQueueStorageKVClient):
         Returns:
             list: List of uninitialized NPU tensors
         """
-        if len(dtypes) != len(shapes):
-            raise ValueError("Length of dtypes must equal length of shapes")
-
         tensors: list[Tensor] = []
-        for dtype, shape in zip(dtypes, shapes, strict=False):
+        for shape, dtype in zip(shapes, dtypes, strict=False):
             tensor = torch.empty(shape, dtype=dtype).to(f"npu:{self.device_id}")
             tensors.append(tensor)
         return tensors
 
-    def put(self, keys: list[str], values: list[Tensor]):
+    def _batch_put(self, keys: list[str], values: list[Any]):
+        if self.npu_ds_client_is_available():
+            cpu_keys = []
+            cpu_values = []
+            npu_keys = []
+            npu_values = []
+            for key, value in zip(keys, values, strict=False):
+                if isinstance(value, torch.Tensor) and value.device.type == "npu":
+                    npu_keys.append(key)
+                    npu_values.append(value)
+                else:
+                    cpu_keys.append(key)
+                    cpu_values.append(pickle.dumps(value))
+            if npu_keys:
+                # _npu_ds_client.dev_mset doesn't support to overwrite
+                try:
+                    self._npu_ds_client.dev_delete(npu_keys)
+                except Exception:
+                    pass
+
+                self._npu_ds_client.dev_mset(npu_keys, npu_values)
+
+            if cpu_keys:
+                self._cpu_ds_client.mset(cpu_keys, cpu_values)
+        else:
+            values = [pickle.dumps(value) for value in values]
+            self._cpu_ds_client.mset(keys, values)
+
+    def put(self, keys: list[str], values: list[Any]):
         """
-        Store tensors to remote storage.
+        Store data(npu tensors, cpu tensors, nontensor, python basic objects) to remote storage.
         Args:
             keys (list): List of string keys
             values (list): List of torch.Tensor on NPU
@@ -70,44 +126,102 @@ class YRStorageClient(TransferQueueStorageKVClient):
         if len(keys) != len(values):
             raise ValueError("Number of keys must match number of values")
 
-        # TODO: Support the situation when the number of keys is greater than 10000
-        if len(keys) > 10000:
-            raise NotImplementedError("We will support the number of keys greater than 10000 int the future")
+        total_count = (len(keys) + self.DS_CLIENT_KEYS_LIMIT - 1) // self.DS_CLIENT_KEYS_LIMIT
+        for i in range(total_count):
+            start_idx = self.DS_CLIENT_KEYS_LIMIT * i
+            end_idx = min(self.DS_CLIENT_KEYS_LIMIT * (i + 1), len(keys))
+            self._batch_put(keys[start_idx:end_idx], values[start_idx:end_idx])
 
-        for value in values:
-            if not isinstance(value, torch.Tensor):
-                raise ValueError(f"Expected torch.Tensor, got {type(value)}")
-            if value.device.type != "npu":
-                raise ValueError(f"Tensor is on {value.device}, not on NPU")
+    def _batch_get(self, keys, shapes, dtypes) -> list[Any]:
+        if self.npu_ds_client_is_available():
+            cpu_keys = []
+            npu_keys = []
+            npu_dtypes = []
+            npu_shapes = []
+            for shape, dtype, key in zip(shapes, dtypes, keys, strict=False):
+                if dtype is not None:
+                    npu_shapes.append(shape)
+                    npu_dtypes.append(dtype)
+                    npu_keys.append(key)
+                else:
+                    cpu_keys.append(key)
 
-        self._ds_client.dev_mset(keys, values)
+            # Note: _npu_ds_client.dev_mget and _cpu_ds_client.get(keys) is assumed
+            # to return values in the same order as keys
+            failed_keys = []
+            npu_values = []
 
-    def get(self, keys: list[str], shapes=None, dtypes=None) -> list[Tensor]:
+            # TODO: _npu_ds_client.dev_mget needs more test,
+            #  because DSTensorClient.dev_mget is currently not stable enough.
+            if npu_keys:
+                npu_values = self._create_empty_npu_tensorlist(npu_shapes, npu_dtypes)
+                try:
+                    failed_keys = self._npu_ds_client.dev_mget(npu_keys, npu_values, 5 * 1000)
+                    # failed_key = f'{key},{device_id}'
+                    failed_keys = [f_key[0:-2] for f_key in failed_keys]
+                except Exception as e:
+                    logger.warning(f"dev_mget error:{e}")
+                    failed_keys = npu_keys
+                    npu_keys = []
+
+            if failed_keys:
+                cpu_keys.extend(failed_keys)
+            cpu_values = []
+            if cpu_keys:
+                cpu_values = self._cpu_ds_client.get(cpu_keys)
+
+            key_to_position = {key: position for position, key in enumerate(keys)}
+
+            values = [None] * len(keys)
+
+            # npu_keys have failed_keys
+            for key, value in zip(npu_keys, npu_values, strict=False):
+                values[key_to_position[key]] = value
+            for key, value in zip(cpu_keys, cpu_values, strict=False):
+                values[key_to_position[key]] = pickle.loads(value)
+        else:
+            values = self._cpu_ds_client.get(keys)
+            values = [pickle.loads(value) for value in values]
+        return values
+
+    def get(self, keys: list[str], shapes=None, dtypes=None) -> list[Any]:
         """
-        Retrieve tensors from remote storage.
+        Retrieve data from remote storage.
         Args:
             keys (list): List of keys to fetch
-            shapes (list): Expected shapes of returned tensors
-            dtypes (list): Expected dtypes of returned tensors
+            shapes (list): Expected shapes of returned data
+            dtypes (list): Expected dtypes of returned data
         Returns:
-            list: List of retrieved NPU tensors
+            list: List of retrieved data
         """
         if shapes is None:
-            raise ValueError("Yuanrong storage client needs Expected shapes of returned tensors")
+            raise ValueError("Yuanrong storage client needs Expected shapes of returned data")
         if dtypes is None:
-            raise ValueError("Yuanrong storage client needs Expected dtypes of returned tensors")
-        if len(dtypes) != len(shapes):
+            raise ValueError("Yuanrong storage client needs Expected dtypes of returned data")
+        if len(dtypes) != len(shapes) or len(keys) != len(shapes):
             raise ValueError("Length of dtypes must equal length of shapes")
 
-        values: list[Tensor] = self._create_empty_tensorlist(shapes=shapes, dtypes=dtypes)
-
-        # TODO: Support the situation when the number of keys is greater than 10000
-        if len(keys) > 10000:
-            raise NotImplementedError("We will support the number of keys greater than 10000 int the future")
-
-        # Timeout set to 2000ms
-        self._ds_client.dev_mget(keys, values, 2000)
+        # Each time, process at most 10,000 keys, and this is done for a total of count times.
+        # The calculation below uses ceiling division (i.e., integer division rounded up).
+        total_count = (len(keys) + self.DS_CLIENT_KEYS_LIMIT - 1) // self.DS_CLIENT_KEYS_LIMIT
+        values = []
+        for i in range(total_count):
+            start_idx = self.DS_CLIENT_KEYS_LIMIT * i
+            end_idx = min(self.DS_CLIENT_KEYS_LIMIT * (i + 1), len(keys))
+            values.extend(
+                self._batch_get(keys[start_idx:end_idx], shapes[start_idx:end_idx], dtypes[start_idx:end_idx])
+            )
         return values
+
+    def _batch_clear(self, keys):
+        if self.npu_ds_client_is_available():
+            # Delete from NPU storage; get keys that failed to delete
+            failed_keys = self._npu_ds_client.dev_delete(keys)
+            # Attempt to delete the failed keys from CPU storage as a fallback
+            if failed_keys:
+                self._cpu_ds_client.delete(failed_keys)
+        else:
+            self._cpu_ds_client.delete(keys)
 
     def clear(self, keys: list[str]):
         """
@@ -115,4 +229,8 @@ class YRStorageClient(TransferQueueStorageKVClient):
         Args:
             keys (list): List of keys to delete
         """
-        self._ds_client.dev_delete(keys)
+        total_count = (len(keys) + self.DS_CLIENT_KEYS_LIMIT - 1) // self.DS_CLIENT_KEYS_LIMIT
+        for i in range(total_count):
+            start_idx = self.DS_CLIENT_KEYS_LIMIT * i
+            end_idx = min(self.DS_CLIENT_KEYS_LIMIT * (i + 1), len(keys))
+            self._batch_clear(keys[start_idx:end_idx])

--- a/transfer_queue/storage/clients/yuanrong_client.py
+++ b/transfer_queue/storage/clients/yuanrong_client.py
@@ -6,13 +6,11 @@ from typing import Any
 import torch
 from torch import Tensor
 
-from transfer_queue.storage.clients.base import TransferQueueStorageKVClient
-from transfer_queue.storage.clients.factory import StorageClientFactory
-
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("TQ_LOGGING_LEVEL", logging.WARNING))
 
-DS_CLIENT_KEYS_LIMIT: int = 1999
+NPU_DS_CLIENT_KEYS_LIMIT = 9999
+CPU_DS_CLIENT_KEYS_LIMIT = 1999
 YUANRONG_DATASYSTEM_IMPORTED: bool = True
 TORCH_NPU_IMPORTED: bool = True
 try:
@@ -25,14 +23,13 @@ except ImportError:
     TORCH_NPU_IMPORTED = False
 
 
-@StorageClientFactory.register("YuanrongStorageClient")
-class YuanrongStorageClient(TransferQueueStorageKVClient):
+class YuanrongStorageClient:
     """
     Storage client for YuanRong DataSystem.
 
-    Supports storing both:
+    Supports storing and fetching both:
     - NPU tensors via DsTensorClient (for high performance).
-    - General objects (CPU tensors, str, bool, list, etc.) via KVClient with pickle serialization.
+    - General objects (CPU tensors, scalars, dicts, etc.) via KVClient with pickle serialization.
     """
 
     def __init__(self, config: dict[str, Any]):
@@ -49,14 +46,12 @@ class YuanrongStorageClient(TransferQueueStorageKVClient):
         if not TORCH_NPU_IMPORTED:
             logger.warning(
                 "'torch_npu' import failed. "
-                "This results in the inability to quickly store and retrieve tensors on the NPU side,"
-                "which may affect performance."
+                "It results in the inability to quickly put/get tensors on the NPU side, which may affect performance."
             )
         elif not torch.npu.is_available():
             logger.warning(
                 "NPU is not available. "
-                "This results in the inability to quickly store and retrieve tensors on the NPU side, "
-                "which may affect performance."
+                "It results in the inability to quickly put/get tensors on the NPU side, which may affect performance."
             )
         else:
             self.device_id = torch.npu.current_device()
@@ -83,158 +78,203 @@ class YuanrongStorageClient(TransferQueueStorageKVClient):
             list: List of uninitialized NPU tensors
         """
         tensors: list[Tensor] = []
-        for shape, dtype in zip(shapes, dtypes, strict=False):
+        for shape, dtype in zip(shapes, dtypes, strict=True):
             tensor = torch.empty(shape, dtype=dtype, device=f"npu:{self.device_id}")
             tensors.append(tensor)
         return tensors
 
     def _batch_put(self, keys: list[str], values: list[Any]):
+        """Stores a batch of key-value pairs to remote storage, splitting by device type.
+
+        NPU tensors are sent via DsTensorClient (with higher batch limit),
+        while all other objects are pickled and sent via KVClient.
+
+        Args:
+            keys (List[str]): List of string keys.
+            values (List[Any]): Corresponding values (tensors or general objects).
+        """
         if self.npu_ds_client_is_available():
-            cpu_keys = []
-            cpu_values = []
+            # Classify NPU and CPU data
             npu_keys = []
             npu_values = []
-            for key, value in zip(keys, values, strict=False):
+
+            cpu_keys = []
+            cpu_values = []
+
+            for key, value in zip(keys, values, strict=True):
                 if isinstance(value, torch.Tensor) and value.device.type == "npu":
                     if not value.is_contiguous():
                         raise ValueError(f"NPU Tensor is not contiguous: {value}")
                     npu_keys.append(key)
                     npu_values.append(value)
+
                 else:
                     cpu_keys.append(key)
                     cpu_values.append(pickle.dumps(value))
 
-            if npu_keys:
+            # put NPU data
+            for i in range(0, len(npu_keys), NPU_DS_CLIENT_KEYS_LIMIT):
+                batch_keys = npu_keys[i : i + NPU_DS_CLIENT_KEYS_LIMIT]
+                batch_values = npu_values[i : i + NPU_DS_CLIENT_KEYS_LIMIT]
+
                 # _npu_ds_client.dev_mset doesn't support to overwrite
                 try:
-                    self._npu_ds_client.dev_delete(npu_keys)
+                    self._npu_ds_client.dev_delete(batch_keys)
                 except Exception as e:
                     logger.warning(f"dev_delete error({e}) before dev_mset")
+                self._npu_ds_client.dev_mset(batch_keys, batch_values)
 
-                self._npu_ds_client.dev_mset(npu_keys, npu_values)
+            # put CPU data
+            for i in range(0, len(cpu_keys), CPU_DS_CLIENT_KEYS_LIMIT):
+                batch_keys = cpu_keys[i : i + CPU_DS_CLIENT_KEYS_LIMIT]
+                batch_values = cpu_values[i : i + CPU_DS_CLIENT_KEYS_LIMIT]
+                self._cpu_ds_client.mset(batch_keys, batch_values)
 
-            if cpu_keys:
-                self._cpu_ds_client.mset(cpu_keys, cpu_values)
         else:
-            values = [pickle.dumps(value) for value in values]
-            self._cpu_ds_client.mset(keys, values)
+            #  All data goes through CPU path
+            pickled_values = [pickle.dumps(v) for v in values]
+            for i in range(0, len(keys), CPU_DS_CLIENT_KEYS_LIMIT):
+                batch_keys = keys[i : i + CPU_DS_CLIENT_KEYS_LIMIT]
+                batch_vals = pickled_values[i : i + CPU_DS_CLIENT_KEYS_LIMIT]
+                self._cpu_ds_client.mset(batch_keys, batch_vals)
 
     def put(self, keys: list[str], values: list[Any]):
-        """
-        Store data(npu tensors, cpu tensors, nontensor, python basic objects) to remote storage.
+        """Stores multiple key-value pairs to remote storage.
+
+        Automatically routes NPU tensors to high-performance tensor storage,
+        and other objects to general-purpose KV storage.
+
         Args:
-            keys (list): List of string keys
-            values (list): List of torch.Tensor on NPU
+            keys (List[str]): List of unique string identifiers.
+            values (List[Any]): List of values to store (tensors, scalars, dicts, etc.).
         """
         if not isinstance(keys, list) or not isinstance(values, list):
             raise ValueError("keys and values must be lists")
         if len(keys) != len(values):
             raise ValueError("Number of keys must match number of values")
+        self._batch_put(keys, values)
 
-        # Each time, process at most DS_CLIENT_KEYS_LIMIT keys, and this is done for a total of count times.
-        # The calculation below uses ceiling division (i.e., integer division rounded up).
-        total_count = (len(keys) + DS_CLIENT_KEYS_LIMIT - 1) // DS_CLIENT_KEYS_LIMIT
-        for i in range(total_count):
-            start_idx = DS_CLIENT_KEYS_LIMIT * i
-            end_idx = min(DS_CLIENT_KEYS_LIMIT * (i + 1), len(keys))
-            self._batch_put(keys[start_idx:end_idx], values[start_idx:end_idx])
+    def _batch_get(self, keys: list[str], shapes: list, dtypes: list) -> list[Any]:
+        """Retrieves a batch of values from remote storage using expected metadata.
 
-    def _batch_get(self, keys, shapes, dtypes) -> list[Any]:
+        NPU tensors are fetched via DsTensorClient using pre-allocated buffers.
+        Other objects are fetched via KVClient and unpickled.
+
+        Args:
+            keys (List[str]): Keys to fetch.
+            shapes (List[List[int]]): Expected shapes for each key (empty list for scalars).
+            dtypes (List[Optional[torch.dtype]]): Expected dtypes; None indicates non-tensor data.
+
+        Returns:
+            List[Any]: Retrieved values in the same order as input keys.
+        """
+
         if self.npu_ds_client_is_available():
-            cpu_keys = []
+            # classify npu and cpu queries
+            npu_indices = []
             npu_keys = []
-            npu_dtypes = []
             npu_shapes = []
-            for shape, dtype, key in zip(shapes, dtypes, keys, strict=False):
+            npu_dtypes = []
+
+            cpu_indices = []
+            cpu_keys = []
+
+            for idx, (key, shape, dtype) in enumerate(zip(keys, shapes, dtypes, strict=False)):
                 if dtype is not None:
+                    npu_indices.append(idx)
+                    npu_keys.append(key)
                     npu_shapes.append(shape)
                     npu_dtypes.append(dtype)
-                    npu_keys.append(key)
                 else:
+                    cpu_indices.append(idx)
                     cpu_keys.append(key)
 
-            # Note: _npu_ds_client.dev_mget and _cpu_ds_client.get(keys) is
-            #       assumed to return values in the same order as keys
-            failed_keys = []
-            npu_values = []
+            results = [None] * len(keys)
 
-            if npu_keys:
-                npu_values = self._create_empty_npu_tensorlist(npu_shapes, npu_dtypes)
+            # Fetch NPU tensors
+            for i in range(0, len(npu_keys), NPU_DS_CLIENT_KEYS_LIMIT):
+                batch_keys = npu_keys[i : i + NPU_DS_CLIENT_KEYS_LIMIT]
+                batch_shapes = npu_shapes[i : i + NPU_DS_CLIENT_KEYS_LIMIT]
+                batch_dtypes = npu_dtypes[i : i + NPU_DS_CLIENT_KEYS_LIMIT]
+                batch_indices = npu_indices[i : i + NPU_DS_CLIENT_KEYS_LIMIT]
+
+                batch_values = self._create_empty_npu_tensorlist(batch_shapes, batch_dtypes)
+                failed_subkeys = []
                 try:
-                    failed_keys = self._npu_ds_client.dev_mget(npu_keys, npu_values)
-                    failed_keys = [f_key.rsplit(",", 1)[0] for f_key in failed_keys]
+                    failed_subkeys = self._npu_ds_client.dev_mget(batch_keys, batch_values)
+                    # failed_keys = f'{key},{npu_device_id}'
+                    failed_subkeys = [f_key.rsplit(",", 1)[0] for f_key in failed_subkeys]
                 except Exception:
-                    failed_keys = npu_keys
-                    npu_keys = []
+                    failed_subkeys = batch_keys
 
-            if failed_keys:
-                cpu_keys.extend(failed_keys)
-            cpu_values = []
-            if cpu_keys:
-                cpu_values = self._cpu_ds_client.get(cpu_keys)
+                # Fill successfully retrieved tensors
+                failed_set = set(failed_subkeys)
+                for idx, key, value in zip(batch_indices, batch_keys, batch_values, strict=False):
+                    if key not in failed_set:
+                        results[idx] = value
 
-            key_to_position = {key: position for position, key in enumerate(keys)}
+                # Add failed keys to CPU fallback queue
+                if failed_subkeys:
+                    cpu_keys.extend(failed_subkeys)
+                    cpu_indices.extend([batch_indices[j] for j, k in enumerate(batch_keys) if k in failed_set])
 
-            values = [None] * len(keys)
+            # Fetch CPU/general objects (including NPU fallbacks)
+            for i in range(0, len(cpu_keys), CPU_DS_CLIENT_KEYS_LIMIT):
+                batch_keys = cpu_keys[i : i + CPU_DS_CLIENT_KEYS_LIMIT]
+                batch_indices = cpu_indices[i : i + CPU_DS_CLIENT_KEYS_LIMIT]
+                raw_values = self._cpu_ds_client.get(batch_keys)
+                for idx, raw_val in zip(batch_indices, raw_values, strict=False):
+                    results[idx] = pickle.loads(raw_val)
 
-            # npu_keys have failed_keys
-            for key, value in zip(npu_keys, npu_values, strict=False):
-                values[key_to_position[key]] = value
-            for key, value in zip(cpu_keys, cpu_values, strict=False):
-                values[key_to_position[key]] = pickle.loads(value)
-        else:
-            values = self._cpu_ds_client.get(keys)
-            values = [pickle.loads(value) for value in values]
-
-        return values
+            return results
 
     def get(self, keys: list[str], shapes=None, dtypes=None) -> list[Any]:
-        """
-        Retrieve data from remote storage.
+        """Retrieves multiple values from remote storage with expected metadata.
+
+        Requires shape and dtype hints to reconstruct NPU tensors correctly.
+
         Args:
-            keys (list): List of keys to fetch
-            shapes (list): Expected shapes of returned data
-            dtypes (list): Expected dtypes of returned data
+            keys (List[str]): Keys to fetch.
+            shapes (List[List[int]]): Expected tensor shapes (use [] for scalars).
+            dtypes (List[Optional[torch.dtype]]): Expected dtypes; use None for non-tensor data.
+
         Returns:
-            list: List of retrieved data
+            List[Any]: Retrieved values in the same order as input keys.
         """
-        if shapes is None:
-            raise ValueError("Yuanrong storage client needs Expected shapes of returned data")
-        if dtypes is None:
-            raise ValueError("Yuanrong storage client needs Expected dtypes of returned data")
-        if len(dtypes) != len(shapes) or len(keys) != len(shapes):
-            raise ValueError("Length of dtypes must equal length of shapes")
+        if shapes is None or dtypes is None:
+            raise ValueError("YuanrongStorageClient needs Expected shapes and dtypes")
+        if not (len(keys) == len(shapes) == len(dtypes)):
+            raise ValueError("Lengths of keys, shapes, dtypes must match")
+        return self._batch_get(keys, shapes, dtypes)
 
-        # Each time, process at most DS_CLIENT_KEYS_LIMIT keys, and this is done for a total of count times.
-        # The calculation below uses ceiling division (i.e., integer division rounded up).
-        total_count = (len(keys) + DS_CLIENT_KEYS_LIMIT - 1) // DS_CLIENT_KEYS_LIMIT
-        values = []
-        for i in range(total_count):
-            start_idx = DS_CLIENT_KEYS_LIMIT * i
-            end_idx = min(DS_CLIENT_KEYS_LIMIT * (i + 1), len(keys))
-            values.extend(
-                self._batch_get(keys[start_idx:end_idx], shapes[start_idx:end_idx], dtypes[start_idx:end_idx])
-            )
-        return values
+    def _batch_clear(self, keys: list[str]):
+        """Deletes a batch of keys from remote storage.
 
-    def _batch_clear(self, keys):
+        Attempts deletion via NPU client first (if available), then falls back to CPU client
+        for any keys not handled by NPU.
+
+        Args:
+            keys (List[str]): Keys to delete.
+        """
         if self.npu_ds_client_is_available():
-            # Delete from NPU storage; get keys that failed to delete
-            failed_keys = self._npu_ds_client.dev_delete(keys)
-            # Attempt to delete the failed keys from CPU storage as a fallback
-            if failed_keys:
-                self._cpu_ds_client.delete(failed_keys)
+            # Try to delete all keys via npu client
+            for i in range(0, len(keys), NPU_DS_CLIENT_KEYS_LIMIT):
+                batch = keys[i : i + NPU_DS_CLIENT_KEYS_LIMIT]
+                # Return the keys that failed to delete
+                self._npu_ds_client.dev_delete(batch)
+                # Delete failed keys via CPU client
+            for j in range(0, len(keys), CPU_DS_CLIENT_KEYS_LIMIT):
+                sub_batch = keys[j : j + CPU_DS_CLIENT_KEYS_LIMIT]
+                self._cpu_ds_client.delete(sub_batch)
         else:
-            self._cpu_ds_client.delete(keys)
+            for i in range(0, len(keys), CPU_DS_CLIENT_KEYS_LIMIT):
+                batch = keys[i : i + CPU_DS_CLIENT_KEYS_LIMIT]
+                self._cpu_ds_client.delete(batch)
 
     def clear(self, keys: list[str]):
-        """
-        Delete entries from storage by keys.
+        """Deletes multiple keys from remote storage.
+
         Args:
-            keys (list): List of keys to delete
+            keys (List[str]): List of keys to remove.
         """
-        total_count = (len(keys) + DS_CLIENT_KEYS_LIMIT - 1) // DS_CLIENT_KEYS_LIMIT
-        for i in range(total_count):
-            start_idx = DS_CLIENT_KEYS_LIMIT * i
-            end_idx = min(DS_CLIENT_KEYS_LIMIT * (i + 1), len(keys))
-            self._batch_clear(keys[start_idx:end_idx])
+        self._batch_clear(keys)

--- a/transfer_queue/storage/clients/yuanrong_client.py
+++ b/transfer_queue/storage/clients/yuanrong_client.py
@@ -20,10 +20,6 @@ try:
     import datasystem
 except ImportError:
     YUANRONG_DATASYSTEM_IMPORTED = False
-try:
-    import torch_npu  # noqa: F401
-except ImportError:
-    TORCH_NPU_IMPORTED = False
 
 
 @StorageClientFactory.register("YuanrongStorageClient")
@@ -39,6 +35,12 @@ class YuanrongStorageClient(TransferQueueStorageKVClient):
     def __init__(self, config: dict[str, Any]):
         if not YUANRONG_DATASYSTEM_IMPORTED:
             raise ImportError("YuanRong DataSystem not installed.")
+
+        global TORCH_NPU_IMPORTED
+        try:
+            import torch_npu  # noqa: F401
+        except ImportError:
+            TORCH_NPU_IMPORTED = False
 
         self.host = config.get("host")
         self.port = config.get("port")

--- a/transfer_queue/storage/clients/yuanrong_client.py
+++ b/transfer_queue/storage/clients/yuanrong_client.py
@@ -12,6 +12,7 @@ from transfer_queue.storage.clients.factory import StorageClientFactory
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("TQ_LOGGING_LEVEL", logging.WARNING))
 
+DS_CLIENT_KEYS_LIMIT: int = 1999
 YUANRONG_DATASYSTEM_IMPORTED: bool = True
 TORCH_NPU_IMPORTED: bool = True
 try:
@@ -25,7 +26,7 @@ except ImportError:
 
 
 @StorageClientFactory.register("Yuanrong")
-class YRStorageClient(TransferQueueStorageKVClient):
+class YuanrongRStorageClient(TransferQueueStorageKVClient):
     """
     Storage client for YuanRong DataSystem.
 
@@ -40,10 +41,11 @@ class YRStorageClient(TransferQueueStorageKVClient):
 
         self.host = config.get("host")
         self.port = config.get("port")
+
+        self.device_id = None
         self._npu_ds_client = None
         self._cpu_ds_client = None
-        self.DS_CLIENT_KEYS_LIMIT = 1000
-        self.device_id = None
+
         if not TORCH_NPU_IMPORTED:
             logger.warning(
                 "'torch_npu' import failed. "
@@ -65,8 +67,7 @@ class YRStorageClient(TransferQueueStorageKVClient):
         self._cpu_ds_client.init()
 
     def npu_ds_client_is_available(self):
-        return False
-        # return self._npu_ds_client is not None
+        return self._npu_ds_client is not None
 
     def cpu_ds_client_is_available(self):
         return self._cpu_ds_client is not None
@@ -74,6 +75,7 @@ class YRStorageClient(TransferQueueStorageKVClient):
     def _create_empty_npu_tensorlist(self, shapes, dtypes):
         """
         Create a list of empty NPU tensors with given shapes and dtypes.
+
         Args:
             shapes (list): List of tensor shapes (e.g., [(3,), (2, 4)])
             dtypes (list): List of torch dtypes (e.g., [torch.float32, torch.int64])
@@ -82,7 +84,7 @@ class YRStorageClient(TransferQueueStorageKVClient):
         """
         tensors: list[Tensor] = []
         for shape, dtype in zip(shapes, dtypes, strict=False):
-            tensor = torch.empty(shape, dtype=dtype).to(f"npu:{self.device_id}")
+            tensor = torch.empty(shape, dtype=dtype, device=f"npu:{self.device_id}")
             tensors.append(tensor)
         return tensors
 
@@ -94,17 +96,20 @@ class YRStorageClient(TransferQueueStorageKVClient):
             npu_values = []
             for key, value in zip(keys, values, strict=False):
                 if isinstance(value, torch.Tensor) and value.device.type == "npu":
+                    if not value.is_contiguous():
+                        raise ValueError(f"NPU Tensor is not contiguous: {value}")
                     npu_keys.append(key)
                     npu_values.append(value)
                 else:
                     cpu_keys.append(key)
                     cpu_values.append(pickle.dumps(value))
+
             if npu_keys:
                 # _npu_ds_client.dev_mset doesn't support to overwrite
                 try:
                     self._npu_ds_client.dev_delete(npu_keys)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"dev_delete error({e}) before dev_mset")
 
                 self._npu_ds_client.dev_mset(npu_keys, npu_values)
 
@@ -126,10 +131,12 @@ class YRStorageClient(TransferQueueStorageKVClient):
         if len(keys) != len(values):
             raise ValueError("Number of keys must match number of values")
 
-        total_count = (len(keys) + self.DS_CLIENT_KEYS_LIMIT - 1) // self.DS_CLIENT_KEYS_LIMIT
+        # Each time, process at most DS_CLIENT_KEYS_LIMIT keys, and this is done for a total of count times.
+        # The calculation below uses ceiling division (i.e., integer division rounded up).
+        total_count = (len(keys) + DS_CLIENT_KEYS_LIMIT - 1) // DS_CLIENT_KEYS_LIMIT
         for i in range(total_count):
-            start_idx = self.DS_CLIENT_KEYS_LIMIT * i
-            end_idx = min(self.DS_CLIENT_KEYS_LIMIT * (i + 1), len(keys))
+            start_idx = DS_CLIENT_KEYS_LIMIT * i
+            end_idx = min(DS_CLIENT_KEYS_LIMIT * (i + 1), len(keys))
             self._batch_put(keys[start_idx:end_idx], values[start_idx:end_idx])
 
     def _batch_get(self, keys, shapes, dtypes) -> list[Any]:
@@ -138,7 +145,7 @@ class YRStorageClient(TransferQueueStorageKVClient):
             npu_keys = []
             npu_dtypes = []
             npu_shapes = []
-            for shape, dtype, key in zip(shapes, dtypes, keys, strict=False):
+            for shape, dtype, key in zip(shapes, dtypes, keys):
                 if dtype is not None:
                     npu_shapes.append(shape)
                     npu_dtypes.append(dtype)
@@ -146,21 +153,16 @@ class YRStorageClient(TransferQueueStorageKVClient):
                 else:
                     cpu_keys.append(key)
 
-            # Note: _npu_ds_client.dev_mget and _cpu_ds_client.get(keys) is assumed
-            # to return values in the same order as keys
+            # Note: _npu_ds_client.dev_mget and _cpu_ds_client.get(keys) is assumed to return values in the same order as keys
             failed_keys = []
             npu_values = []
 
-            # TODO: _npu_ds_client.dev_mget needs more test,
-            #  because DSTensorClient.dev_mget is currently not stable enough.
             if npu_keys:
                 npu_values = self._create_empty_npu_tensorlist(npu_shapes, npu_dtypes)
                 try:
-                    failed_keys = self._npu_ds_client.dev_mget(npu_keys, npu_values, 5 * 1000)
-                    # failed_key = f'{key},{device_id}'
-                    failed_keys = [f_key[0:-2] for f_key in failed_keys]
-                except Exception as e:
-                    logger.warning(f"dev_mget error:{e}")
+                    failed_keys = self._npu_ds_client.dev_mget(npu_keys, npu_values)
+                    failed_keys = [f_key.rsplit(',', 1)[0] for f_key in failed_keys]
+                except Exception:
                     failed_keys = npu_keys
                     npu_keys = []
 
@@ -182,6 +184,7 @@ class YRStorageClient(TransferQueueStorageKVClient):
         else:
             values = self._cpu_ds_client.get(keys)
             values = [pickle.loads(value) for value in values]
+
         return values
 
     def get(self, keys: list[str], shapes=None, dtypes=None) -> list[Any]:
@@ -201,13 +204,13 @@ class YRStorageClient(TransferQueueStorageKVClient):
         if len(dtypes) != len(shapes) or len(keys) != len(shapes):
             raise ValueError("Length of dtypes must equal length of shapes")
 
-        # Each time, process at most 10,000 keys, and this is done for a total of count times.
+        # Each time, process at most DS_CLIENT_KEYS_LIMIT keys, and this is done for a total of count times.
         # The calculation below uses ceiling division (i.e., integer division rounded up).
-        total_count = (len(keys) + self.DS_CLIENT_KEYS_LIMIT - 1) // self.DS_CLIENT_KEYS_LIMIT
+        total_count = (len(keys) + DS_CLIENT_KEYS_LIMIT - 1) // DS_CLIENT_KEYS_LIMIT
         values = []
         for i in range(total_count):
-            start_idx = self.DS_CLIENT_KEYS_LIMIT * i
-            end_idx = min(self.DS_CLIENT_KEYS_LIMIT * (i + 1), len(keys))
+            start_idx = DS_CLIENT_KEYS_LIMIT * i
+            end_idx = min(DS_CLIENT_KEYS_LIMIT * (i + 1), len(keys))
             values.extend(
                 self._batch_get(keys[start_idx:end_idx], shapes[start_idx:end_idx], dtypes[start_idx:end_idx])
             )
@@ -229,8 +232,8 @@ class YRStorageClient(TransferQueueStorageKVClient):
         Args:
             keys (list): List of keys to delete
         """
-        total_count = (len(keys) + self.DS_CLIENT_KEYS_LIMIT - 1) // self.DS_CLIENT_KEYS_LIMIT
+        total_count = (len(keys) + DS_CLIENT_KEYS_LIMIT - 1) // DS_CLIENT_KEYS_LIMIT
         for i in range(total_count):
-            start_idx = self.DS_CLIENT_KEYS_LIMIT * i
-            end_idx = min(self.DS_CLIENT_KEYS_LIMIT * (i + 1), len(keys))
+            start_idx = DS_CLIENT_KEYS_LIMIT * i
+            end_idx = min(DS_CLIENT_KEYS_LIMIT * (i + 1), len(keys))
             self._batch_clear(keys[start_idx:end_idx])

--- a/transfer_queue/storage/clients/yuanrong_client.py
+++ b/transfer_queue/storage/clients/yuanrong_client.py
@@ -6,11 +6,14 @@ from typing import Any
 import torch
 from torch import Tensor
 
+from transfer_queue.storage.clients.base import TransferQueueStorageKVClient
+from transfer_queue.storage.clients.factory import StorageClientFactory
+
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("TQ_LOGGING_LEVEL", logging.WARNING))
 
-NPU_DS_CLIENT_KEYS_LIMIT = 9999
-CPU_DS_CLIENT_KEYS_LIMIT = 1999
+NPU_DS_CLIENT_KEYS_LIMIT: int = 9999
+CPU_DS_CLIENT_KEYS_LIMIT: int = 1999
 YUANRONG_DATASYSTEM_IMPORTED: bool = True
 TORCH_NPU_IMPORTED: bool = True
 try:
@@ -23,13 +26,14 @@ except ImportError:
     TORCH_NPU_IMPORTED = False
 
 
-class YuanrongStorageClient:
+@StorageClientFactory.register("YuanrongStorageClient")
+class YuanrongStorageClient(TransferQueueStorageKVClient):
     """
     Storage client for YuanRong DataSystem.
 
     Supports storing and fetching both:
     - NPU tensors via DsTensorClient (for high performance).
-    - General objects (CPU tensors, scalars, dicts, etc.) via KVClient with pickle serialization.
+    - General objects (CPU tensors, str, bool, list, etc.) via KVClient with pickle serialization.
     """
 
     def __init__(self, config: dict[str, Any]):
@@ -78,7 +82,7 @@ class YuanrongStorageClient:
             list: List of uninitialized NPU tensors
         """
         tensors: list[Tensor] = []
-        for shape, dtype in zip(shapes, dtypes, strict=True):
+        for shape, dtype in zip(shapes, dtypes, strict=False):
             tensor = torch.empty(shape, dtype=dtype, device=f"npu:{self.device_id}")
             tensors.append(tensor)
         return tensors

--- a/transfer_queue/storage/managers/__init__.py
+++ b/transfer_queue/storage/managers/__init__.py
@@ -15,9 +15,11 @@
 from .base import TransferQueueStorageManager
 from .factory import TransferQueueStorageManagerFactory
 from .simple_backend_manager import AsyncSimpleStorageManager
+from .yuanrong_manager import YuanrongStorageManager
 
 __all__ = [
     "TransferQueueStorageManager",
     "TransferQueueStorageManagerFactory",
     "AsyncSimpleStorageManager",
+    "YuanrongStorageManager",
 ]

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -295,6 +295,7 @@ class TransferQueueStorageManager(ABC):
         except Exception as e:
             logger.error(f"[{self.storage_manager_id}]: Exception during __del__: {str(e)}")
 
+
 class KVStorageManager(TransferQueueStorageManager):
     """
     A storage manager that uses a key-value (KV) backend (e.g., YuanRong) to store and retrieve tensor data.

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -369,6 +369,7 @@ class KVStorageManager(TransferQueueStorageManager):
         grouped_data: dict[str, list[Tensor]] = {field: [] for field in field_names}
 
         # Group values by field_name
+        # TODO: Performance optimize
         value_idx = 0
         for field in field_names:
             for _ in range(len(global_indexes)):
@@ -376,6 +377,7 @@ class KVStorageManager(TransferQueueStorageManager):
                 value_idx += 1
 
         # Stack or nest tensors per field
+        # TODO: These codes about data merging will serve as a general function
         merged_data = {}
         for field, data_list in grouped_data.items():
             if all(isinstance(item, torch.Tensor) for item in data_list):

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -273,28 +273,6 @@ class TransferQueueStorageManager(ABC):
     async def clear_data(self, metadata: BatchMeta) -> None:
         raise NotImplementedError("Subclasses must implement clear_data")
 
-    def close(self) -> None:
-        """Close all ZMQ sockets and context to prevent resource leaks."""
-        for sock in (self.controller_handshake_socket, self.data_status_update_socket):
-            try:
-                if sock and not sock.closed:
-                    sock.close(linger=0)
-            except Exception as e:
-                logger.error(f"[{self.storage_manager_id}]: Error closing socket {sock}: {str(e)}")
-
-        try:
-            if self.zmq_context:
-                self.zmq_context.term()
-        except Exception as e:
-            logger.error(f"[{self.storage_manager_id}]: Error terminating zmq_context: {str(e)}")
-
-    def __del__(self):
-        """Destructor to ensure resources are cleaned up."""
-        try:
-            self.close()
-        except Exception as e:
-            logger.error(f"[{self.storage_manager_id}]: Exception during __del__: {str(e)}")
-
 
 class KVStorageManager(TransferQueueStorageManager):
     """
@@ -306,8 +284,10 @@ class KVStorageManager(TransferQueueStorageManager):
         """
         Initialize the KVStorageManager with configuration.
         """
+        client_name = config.get("client_name", None)
+        if client_name is None:
+            raise ValueError("Missing client_name in config")
         super().__init__(config)
-        client_name = config.get("client_name", "Yuanrong")
         self.storage_client = StorageClientFactory.create(client_name, config)
 
     @staticmethod
@@ -340,11 +320,6 @@ class KVStorageManager(TransferQueueStorageManager):
             list[Tensor]: Flattened list of tensors, e.g.,
                           [data[field_a][0], data[field_a][1], data[field_a][2], ..., data[field_b][0], ...]
         """
-        # TODO: We will support more complex data types ( NonTensorStack/ NonTensorData/ NestedTensor)
-        for v in data.values():
-            if not torch.is_tensor(v):
-                raise TypeError(f"TensorDict values must be torch.Tensor, but got {type(v)}")
-
         return [row_data for field in sorted(data.keys()) for row_data in data[field]]
 
     @staticmethod
@@ -412,7 +387,6 @@ class KVStorageManager(TransferQueueStorageManager):
                 dtypes.append(field.dtype)
         return shapes, dtypes
 
-    # TODO: Test put_data/get_data/clear_data with YuanrongStorageClient
     async def put_data(self, data: TensorDict, metadata: BatchMeta) -> None:
         """
         Store tensor data in the backend storage and notify the controller.
@@ -421,9 +395,13 @@ class KVStorageManager(TransferQueueStorageManager):
         extracts per-sample dtype and shape information, and sends a notification
         to the controller that new data is available.
         """
+        if not metadata.field_names:
+            logger.warning("Attempted to put data, but metadata contains no fields.")
+            return
         keys = self._generate_keys(metadata)
         values = self._generate_values(data)
         self.storage_client.put(keys=keys, values=values)
+
         per_field_dtypes = {}
         per_field_shapes = {}
 
@@ -433,14 +411,20 @@ class KVStorageManager(TransferQueueStorageManager):
             per_field_shapes[global_idx] = {}
 
         # For each field, extract dtype and shape for each sample
-        for field in data.keys():
-            for i, data_item in enumerate(data[field]):
+        for field_name, field_data in data.items():
+            for i, data_item in enumerate(field_data):
                 global_idx = metadata.global_indexes[i]
-                per_field_dtypes[global_idx][field] = data_item.dtype if hasattr(data_item, "dtype") else None
-                per_field_shapes[global_idx][field] = data_item.shape if hasattr(data_item, "shape") else None
+                per_field_dtypes[global_idx][field_name] = getattr(data_item, "dtype", None)
+                per_field_shapes[global_idx][field_name] = getattr(data_item, "shape", None)
 
+        # Get current data partition id
+        # Note: Currently we only support putting to & getting data from a single data partition simultaneously,
+        # but in the future we may support putting to & getting data from multiple data partitions concurrently.
+        partition_id = metadata.samples[0].partition_id
         # notify controller that new data is ready
-        await self.notify_data_update(list(data.keys()), metadata.global_indexes, per_field_dtypes, per_field_shapes)
+        await self.notify_data_update(
+            partition_id, list(data.keys()), metadata.global_indexes, per_field_dtypes, per_field_shapes
+        )
 
     async def get_data(self, metadata: BatchMeta) -> TensorDict:
         """
@@ -449,6 +433,9 @@ class KVStorageManager(TransferQueueStorageManager):
         Fetches tensors using the provided metadata, reconstructs them with the
         correct shapes and dtypes, and merge them as a TensorDict according to metadata.
         """
+        if not metadata.field_names:
+            logger.warning("Attempted to get data, but metadata contains no fields.")
+            return TensorDict({}, batch_size=len(metadata))
         keys = self._generate_keys(metadata)
         shapes, dtypes = self._get_shape_type_list(metadata)
         values = self.storage_client.get(keys=keys, shapes=shapes, dtypes=dtypes)
@@ -456,5 +443,8 @@ class KVStorageManager(TransferQueueStorageManager):
 
     async def clear_data(self, metadata: BatchMeta) -> None:
         """Remove stored data associated with the given metadata."""
+        if not metadata.field_names:
+            logger.warning("Attempted to clear data, but metadata contains no fields.")
+            return
         keys = self._generate_keys(metadata)
         self.storage_client.clear(keys=keys)

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -313,21 +313,19 @@ class KVStorageManager(TransferQueueStorageManager):
         self.storage_client = StorageClientFactory.create(client_name, config)
 
     @staticmethod
-    def _generate_keys(metadata: BatchMeta) -> list[str]:
+    def _generate_keys(field_names: list[str], global_indexes: list[int]) -> list[str]:
         """
         Generate KV keys in the format 'global_index@field_name' for all sample-field pairs.
         Keys are generated in sorted order by field name first, then by global index,
         ensuring consistent ordering for batched operations.
 
         Args:
-            metadata (BatchMeta): Metadata containing global indexes and field names.
+            field_names : list of field names.
+            global_indexes : list of global indexes.
         Returns:
             list[str]: List of keys, e.g., ['0@field_a', '1@field_a', '0@field_b', ...]
         """
-        return [
-            f"{index}@{field}"
-            for field, index in itertools.product(sorted(metadata.field_names), metadata.global_indexes)
-        ]
+        return [f"{index}@{field}" for field, index in itertools.product(sorted(field_names), global_indexes)]
 
     @staticmethod
     def _generate_values(data: TensorDict) -> list[Tensor]:
@@ -426,7 +424,7 @@ class KVStorageManager(TransferQueueStorageManager):
         if not metadata.field_names:
             logger.warning("Attempted to put data, but metadata contains no fields.")
             return
-        keys = self._generate_keys(metadata)
+        keys = self._generate_keys(data.keys(), metadata.global_indexes)
         values = self._generate_values(data)
         self.storage_client.put(keys=keys, values=values)
 
@@ -468,7 +466,7 @@ class KVStorageManager(TransferQueueStorageManager):
         if not metadata.field_names:
             logger.warning("Attempted to get data, but metadata contains no fields.")
             return TensorDict({}, batch_size=len(metadata))
-        keys = self._generate_keys(metadata)
+        keys = self._generate_keys(metadata.field_names, metadata.global_indexes)
         shapes, dtypes = self._get_shape_type_list(metadata)
         values = self.storage_client.get(keys=keys, shapes=shapes, dtypes=dtypes)
         return self._merge_tensors_to_tensordict(metadata, values)

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 
 import torch
 import zmq
-from tensordict import TensorDict
+from tensordict import NonTensorStack, TensorDict
 from torch import Tensor
 
 from transfer_queue.metadata import BatchMeta
@@ -368,25 +368,31 @@ class KVStorageManager(TransferQueueStorageManager):
         if len(values) == 0:
             return TensorDict({}, batch_size=len(global_indexes))
 
-        merged_data: dict[str, list[Tensor]] = {field: [] for field in field_names}
+        grouped_data: dict[str, list[Tensor]] = {field: [] for field in field_names}
 
         # Group values by field_name
         value_idx = 0
         for field in field_names:
             for _ in range(len(global_indexes)):
-                merged_data[field].append(values[value_idx])
+                grouped_data[field].append(values[value_idx])
                 value_idx += 1
 
         # Stack or nest tensors per field
-        tensor_data = {}
-        for field, tensor_list in merged_data.items():
-            try:
-                tensor_data[field] = torch.stack(tensor_list)
-            except RuntimeError:
-                # Fallback to nested tensor if shapes are irregular
-                tensor_data[field] = torch.nested.as_nested_tensor(tensor_list)
+        merged_data = {}
+        for field, data_list in grouped_data.items():
+            if all(isinstance(item, torch.Tensor) for item in data_list):
+                try:
+                    merged_data[field] = torch.stack(data_list)
+                except RuntimeError:
+                    try:
+                        # Fallback to nested tensor if shapes are irregular
+                        merged_data[field] = torch.nested.as_nested_tensor(data_list)
+                    except Exception:
+                        merged_data[field] = NonTensorStack(*data_list)
+            else:
+                merged_data[field] = NonTensorStack(*data_list)
 
-        return TensorDict(tensor_data, batch_size=len(global_indexes))
+        return TensorDict(merged_data, batch_size=len(global_indexes))
 
     @staticmethod
     def _get_shape_type_list(metadata: BatchMeta):
@@ -436,8 +442,12 @@ class KVStorageManager(TransferQueueStorageManager):
         for field_name, field_data in data.items():
             for i, data_item in enumerate(field_data):
                 global_idx = metadata.global_indexes[i]
-                per_field_dtypes[global_idx][field_name] = getattr(data_item, "dtype", None)
-                per_field_shapes[global_idx][field_name] = getattr(data_item, "shape", None)
+                per_field_dtypes[global_idx][field_name] = (
+                    getattr(data_item, "dtype", None) if isinstance(data_item, Tensor) else None
+                )
+                per_field_shapes[global_idx][field_name] = (
+                    getattr(data_item, "shape", None) if isinstance(data_item, Tensor) else None
+                )
 
         # Get current data partition id
         # Note: Currently we only support putting to & getting data from a single data partition simultaneously,

--- a/transfer_queue/storage/managers/base.py
+++ b/transfer_queue/storage/managers/base.py
@@ -273,6 +273,27 @@ class TransferQueueStorageManager(ABC):
     async def clear_data(self, metadata: BatchMeta) -> None:
         raise NotImplementedError("Subclasses must implement clear_data")
 
+    def close(self) -> None:
+        """Close all ZMQ sockets and context to prevent resource leaks."""
+        for sock in (self.controller_handshake_socket, self.data_status_update_socket):
+            try:
+                if sock and not sock.closed:
+                    sock.close(linger=0)
+            except Exception as e:
+                logger.error(f"[{self.storage_manager_id}]: Error closing socket {sock}: {str(e)}")
+
+        try:
+            if self.zmq_context:
+                self.zmq_context.term()
+        except Exception as e:
+            logger.error(f"[{self.storage_manager_id}]: Error terminating zmq_context: {str(e)}")
+
+    def __del__(self):
+        """Destructor to ensure resources are cleaned up."""
+        try:
+            self.close()
+        except Exception as e:
+            logger.error(f"[{self.storage_manager_id}]: Exception during __del__: {str(e)}")
 
 class KVStorageManager(TransferQueueStorageManager):
     """

--- a/transfer_queue/storage/managers/yuanrong_manager.py
+++ b/transfer_queue/storage/managers/yuanrong_manager.py
@@ -21,8 +21,8 @@ class YuanrongStorageManager(KVStorageManager):
         if port is None or not isinstance(port, int):
             raise ValueError("Missing or invalid 'port' in config")
         if client_name is None:
-            logger.info("Missing 'client_name in config, using default value('Yuanrong')")
-            config["client_name"] = "Yuanrong"
-        elif client_name != "Yuanrong":
-            raise ValueError("Invalid 'client_name' in config")
+            logger.info("Missing 'client_name' in config, using default value('YuanrongStorageClient')")
+            config["client_name"] = "YuanrongStorageClient"
+        elif client_name != "YuanrongStorageClient":
+            raise ValueError(f"Invalid 'client_name': {client_name} in config. Expecting 'YuanrongStorageClient' for YuanrongStorageManager")
         super().__init__(config)

--- a/transfer_queue/storage/managers/yuanrong_manager.py
+++ b/transfer_queue/storage/managers/yuanrong_manager.py
@@ -21,8 +21,8 @@ class YuanrongStorageManager(KVStorageManager):
         if port is None or not isinstance(port, int):
             raise ValueError("Missing or invalid 'port' in config")
         if client_name is None:
-            logger.info("Missing 'client_name in config, using default value('yuanrong')")
-            config["client_name"] = "yuanrong"
-        elif client_name != "yuanrong":
+            logger.info("Missing 'client_name in config, using default value('Yuanrong')")
+            config["client_name"] = "Yuanrong"
+        elif client_name != "Yuanrong":
             raise ValueError("Invalid 'client_name' in config")
         super().__init__(config)

--- a/transfer_queue/storage/managers/yuanrong_manager.py
+++ b/transfer_queue/storage/managers/yuanrong_manager.py
@@ -24,5 +24,5 @@ class YuanrongStorageManager(KVStorageManager):
             logger.info("Missing 'client_name' in config, using default value('YuanrongStorageClient')")
             config["client_name"] = "YuanrongStorageClient"
         elif client_name != "YuanrongStorageClient":
-            raise ValueError(f"Invalid 'client_name': {client_name} in config. Expecting 'YuanrongStorageClient' for YuanrongStorageManager")
+            raise ValueError(f"Invalid 'client_name': {client_name} in config. Expecting 'YuanrongStorageClient'")
         super().__init__(config)

--- a/transfer_queue/storage/managers/yuanrong_manager.py
+++ b/transfer_queue/storage/managers/yuanrong_manager.py
@@ -1,18 +1,28 @@
+import logging
+import os
 from typing import Any
 
 from transfer_queue.storage.managers.base import KVStorageManager
+from transfer_queue.storage.managers.factory import TransferQueueStorageManagerFactory
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("TQ_LOGGING_LEVEL", logging.WARNING))
 
 
+@TransferQueueStorageManagerFactory.register("YuanrongStorageManager")
 class YuanrongStorageManager(KVStorageManager):
     def __init__(self, config: dict[str, Any]):
         host = config.get("host", None)
         port = config.get("port", None)
-        device_id = config.get("device_id", None)
+        client_name = config.get("client_name", None)
+
         if host is None or not isinstance(host, str):
             raise ValueError("Missing or invalid 'host' in config")
         if port is None or not isinstance(port, int):
             raise ValueError("Missing or invalid 'port' in config")
-        # TODO: device_id may be a list[int]
-        if device_id is None or not isinstance(device_id, int):
-            raise ValueError("Missing or invalid 'device_id' in config")
+        if client_name is None:
+            logger.info("Missing 'client_name in config, using default value('yuanrong')")
+            config["client_name"] = "yuanrong"
+        elif client_name != "yuanrong":
+            raise ValueError("Invalid 'client_name' in config")
         super().__init__(config)


### PR DESCRIPTION
## Description

The current `YRStorageClient` only supports storage of NPU tensors and cannot handle CPU tensors or non-tensor data (e.g., bool, str, list, etc.). To improve its generality and system flexibility, this PR refactors the `YRStorageClient` in `transfer_queue/storage/clients/yuanrong_client.py` and updates related storagemanagers to uniformly support the following data types:

- CPU tensors (`torch.Tensor` on CPU)  
- Non-tensor objects (arbitrary serializable Python objects)  
- (Future) NPU tensors (currently unstable due to limitations in the underlying storage system)

## Key Changes

- Introduced a dedicated `_cpu_ds_client` in `YRStorageClient` to handle all non-NPU data, including CPU tensors and generic Python objects.

- Removed the `device_id` parameter from `YRStorageClient.__init__`, decoupling the client from explicit device binding.

- Optimized the `put` / `get` / `clear` interfaces to efficiently support large-volume data operations.

- Adapted `KVStorageManager` and `YuanrongStorageManager` to correctly interface with the new `YRStorageClient` API.

## Files Modified

- `storage/clients/yuanrong_client.py`
- `storage/managers/base.py`
- `storage/managers/yuanrong_manager.py`

## Performance test
- Setup
  -  `Tensor.shape=[1024]`
  -  Data system single-machine deployment
- Result
  - [NPU]: NPU tensors
  - [CPU]: CPU tensors
  - Note: Performance may fluctuate to some extent. For 100,000 keys, the put-get-clear operation can be completed in as fast as 40 seconds. The time includes the cold start of the data system.


<img width="346" height="528" alt="image" src="https://github.com/user-attachments/assets/0f2e2da5-c7e9-4a4c-ae25-7be0ea7ab67b" />

<details>
<summary>Codes (Click) : Test performance of three methods `get/put/clear`</summary>

```python
# benchmark.py
import time
from tracemalloc import Statistic
import torch
import torch_npu
import statistics
from storageclient_dev import YuanrongStorageClient
from async_storageclient import YuanrongStorageClient_Async

def quick_tensor_list_equal(a, b):
    return len(a) == len(b) and all(torch.equal(x, y) for x, y in zip(a, b))
def test_npu(n_batches):
    client = YuanrongStorageClient(config)
    t1=[]
    for i in range(5):
        keys = [f"k_{i}" for i in range(num_keys)]
        #vals = [torch.randn(tensor_shape) for _ in range(num_keys)]
        vals = [torch.randn(tensor_shape).npu(npu_id) for _ in range(num_keys)]
        shapes = [v.shape for v in vals]   
        dtypes = [v.dtype for v in vals]
        start = time.time()
        client.put(keys, vals)
        ret_vals = client.get(keys, shapes,dtypes)
        assert quick_tensor_list_equal(vals, ret_vals)
        client.clear(keys)
        t1.append(time.time() - start)
    return statistics.mean(sorted(t1)[1:-1])

def test_cpu(num_keys):
    client = YuanrongStorageClient(config)
    t2=[]
    for i in range(5):
        keys = [f"k_{i}" for i in range(num_keys)]
        vals = [torch.randn(tensor_shape) for _ in range(num_keys)]
        #vals = [torch.randn(tensor_shape).npu(npu_id) for _ in range(num_keys)]
        shapes = [v.shape for v in vals]   
        dtypes = [v.dtype for v in vals]
        start = time.time()
        client.put(keys, vals)
        ret_vals = client.get(keys, shapes,dtypes)
        assert quick_tensor_list_equal(vals, ret_vals)
        client.clear(keys)
        t2.append(time.time() - start)
    return statistics.mean(sorted(t2)[1:-1])

if __name__ == "__main__":
    npu_id=5
    tensor_shape=1024
    torch_npu.npu.set_device(f'npu:{npu_id}')
    config={"host":"127.0.0.1", "port":31511}
    for N_BATCHES in [5, 20, 100, 200, 500, 800, 1000]:
        num_keys = N_BATCHES * 100
        print(f"Testing with {num_keys} keys ")
    
        # NPU
        avg_t1 = test_npu(num_keys)
        print(f"[NPU]          Time: {avg_t1:.3f}s")
        
        # CPU  
        avg_t2 = test_cpu(num_keys)
        print(f"[CPU]         Time: {avg_t2:.3f}s")
    
    

```
</details>

## Integration test
- Environment
  - OS:  eulerOS2r10
  - Architure: aarch64
  - NPU: 910B
  - chariot-ds: 0.1.6
- Test: 
Modify the code in [`async_demo.py`](https://github.com/TransferQueue/TransferQueue/blob/dev/recipe/simple_use_case/async_demo.py) as follows:

<details>
<summary>Codes (Click) : Integration test with the entire TransferQueue</summary>

```python
# Copyright 2025 The TransferQueue Team
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

import asyncio
import logging
import math
import os
import sys
import time
from pathlib import Path
try:
    import torch_npu
    print("NPU device count:", torch_npu.npu.device_count())
except Exception as e:
    print("NPU not available:", e)
import ray
import torch
from omegaconf import OmegaConf
from tensordict import NonTensorData, TensorDict

parent_dir = Path(__file__).resolve().parent.parent.parent
sys.path.append(str(parent_dir))

from transfer_queue import (  # noqa: E402
    AsyncTransferQueueClient,
    BatchMeta,
    SimpleStorageUnit,
    TransferQueueController,
    process_zmq_server_info,
)
from transfer_queue.utils.utils import get_placement_group  # noqa: E402

logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
logger = logging.getLogger(__name__)

os.environ["RAY_DEDUP_LOGS"] = "0"
os.environ["RAY_DEBUG"] = "1"
ray.init()


def compute_old_log_prob(data1, data2):
    time.sleep(3)
    return data1


def generate_sequences(data):
    time.sleep(3)
    return data


class ActorRolloutRefWorker:
    def actor_rollout_wg_generate_sequences(self, data_meta, data_system_client):
        # 1. Pull real data from the storage plane through client based on data_meta
        data = asyncio.run(data_system_client.async_get_data(data_meta))
        logger.info(f"demo get data->generate_sequences {data}")

        output = generate_sequences(data["input_ids"])

        output = TensorDict(
            {
                "generate_sequences_ids": output,
                "non_tensor_data": torch.stack([NonTensorData("test_str") for _ in range(output.size(0))]),
                "nested_tensor": torch.nested.as_nested_tensor([torch.randn(1, 2) for _ in range(output.size(0))]),
            },
            batch_size=output.size(0),
        )

        # 2. Write results back to the storage plane based on data_meta
        asyncio.run(data_system_client.async_put(data=output, metadata=data_meta))
        data_meta.add_fields(output)
        logger.info("demo put data to storages done")

        return data_meta

    def actor_rollout_wg_compute_old_log_prob(self, data_meta, data_system_client):
        # 1. Pull real data from the storage plane through client based on data_meta
        data = asyncio.run(data_system_client.async_get_data(data_meta))
        logger.info(f"demo get data->old_log_prob {data}")

        output = compute_old_log_prob(data["input_ids"], data["generate_sequences_ids"])

        output = TensorDict({"old_log_prob": output}, batch_size=output.size(0))

        # 2. Write results back to the storage plane based on data_meta
        asyncio.run(data_system_client.async_put(data=output, metadata=data_meta))
        data_meta.add_fields(output)
        logger.info("demo put data to storages done")

        return data_meta


@ray.remote(resources={"NPU": 1})
class AsyncvLLMServer:
    def __init__(self, config, data_system_controller_info):
        self.config = config
        self.data_system_client = AsyncTransferQueueClient(
            client_id="AsyncvLLMServer",
            controller_info=data_system_controller_info,
        )

        self.data_system_client.initialize_storage_manager(manager_type="YuanrongStorageManager", config=self.config)

    async def generate(self, data_meta):
        data = await self.data_system_client.async_get_data(data_meta)
        logger.info(f"demo get data->generate_sequences {data}")

        data = data["input_ids"]
        data += 1
        await asyncio.sleep(3)

        output = TensorDict(
            {
                "generate_sequences_ids": data,
                "non_tensor_data": torch.stack([NonTensorData("test_str") for _ in range(data.size(0))]),
                "nested_tensor": torch.nested.as_nested_tensor([torch.randn(1, 2) for _ in range(data.size(0))]),
            },
            batch_size=data.size(0),
        )

        await self.data_system_client.async_put(data=output, metadata=data_meta)
        logger.info("demo Async Server put data to storages done")

        return data_meta


@ray.remote(num_cpus=1, resources={"NPU": 1})
class AsyncRolloutWorker:
    def __init__(
        self,
        config,
        data_system_controller_info,
    ):
        self.async_vllm_server = AsyncvLLMServer.remote(
            config,
            data_system_controller_info,
        )

    async def generate_sequences(self, data_meta_chunk):
        tasks = []
        for i in range(data_meta_chunk.size):
            # asyncio.create_task cannot directly call Ray Actor methods,
            # otherwise an error will be reported：a coroutine was expected, got ObjectRef(xxx)
            tasks.append(asyncio.create_task(self.generate(data_meta_chunk[i])))
        data_metas = await asyncio.gather(*tasks)
        return BatchMeta.concat(data_metas)

    async def generate(self, data_meta):
        data_meta_new = await self.async_vllm_server.generate.remote(data_meta)
        return data_meta_new


class RolloutManager:
    def __init__(self, config, data_system_storage_unit_infos, data_system_controller_info):
        self.config = config

        self.data_system_client = AsyncTransferQueueClient(
            client_id="RolloutManager",
            controller_info=data_system_controller_info,
        )

        self.data_system_client.initialize_storage_manager(manager_type="YuanrongStorageManager", config=self.config)

        self.async_rollout_workers = []
        num_workers = self.config.rollout_agent_num_workers
        for i in range(num_workers):
            self.async_rollout_workers.append(AsyncRolloutWorker.remote(config, data_system_controller_info))

    def generate_sequences(self, data_meta):
        data_meta_chunkes = data_meta.chunk(len(self.async_rollout_workers))
        data_metas = ray.get(
            [
                worker.generate_sequences.remote(data_meta_chunk)
                for worker, data_meta_chunk in zip(self.async_rollout_workers, data_meta_chunkes, strict=True)
            ]
        )
        batch_meta = BatchMeta.concat(data_metas)
        logger.info(f"batch_meta: {batch_meta}")

        return batch_meta


class Trainer:
    def __init__(self, config):
        self.config = config
        self.data_system_client = self._initialize_data_system()
        self.actor_rollout_wg = ActorRolloutRefWorker()
        self.async_rollout_manager = RolloutManager(
            self.config,
            self.data_system_storage_unit_infos,
            self.data_system_controller_info,
        )

    def _initialize_data_system(self):
        # 1. Initialize TransferQueueStorage
        total_storage_size = self.config.global_batch_size * self.config.num_global_batch * self.config.num_n_samples
        self.data_system_storage_units = {}
        storage_placement_group = get_placement_group(self.config.num_data_storage_units, num_cpus_per_actor=1)
        for storage_unit_rank in range(self.config.num_data_storage_units):
            storage_node = SimpleStorageUnit.options(
                placement_group=storage_placement_group, placement_group_bundle_index=storage_unit_rank
            ).remote(storage_unit_size=math.ceil(total_storage_size / self.config.num_data_storage_units))
            self.data_system_storage_units[storage_unit_rank] = storage_node
            logger.info(f"SimpleStorageUnit #{storage_unit_rank} has been created.")

        # 2. Initialize TransferQueueController (single controller only)

        # Sampler usage instructions:
        # For GRPO grouped sampling, you can initialize the controller with GRPOGroupNSampler:
        # Option 1: Pass sampler class (will be instantiated automatically)
        # self.data_system_controller = TransferQueueController.remote(sampler=GRPOGroupNSampler)

        # Option 2: Pass sampler instance (if you need custom configuration)
        # grpo_sampler = GRPOGroupNSampler()
        # self.data_system_controller = TransferQueueController.remote(sampler=grpo_sampler)

        # Then use sampling_config in get_meta calls:
        # sampling_config={"n_samples_per_prompt": 4}
        self.data_system_controller = TransferQueueController.remote()
        logger.info("TransferQueueController has been created.")

        # 3. Prepare necessary information
        self.data_system_controller_info = process_zmq_server_info(self.data_system_controller)
        self.data_system_storage_unit_infos = process_zmq_server_info(self.data_system_storage_units)

        tq_config = OmegaConf.create({}, flags={"allow_objects": True})  # Note: Need to generate a new DictConfig
        # with allow_objects=True to maintain ZMQServerInfo instance. Otherwise it will be flattened to dict
        tq_config.controller_info = self.data_system_controller_info
        tq_config.storage_unit_infos = self.data_system_storage_unit_infos
        self.config = OmegaConf.merge(tq_config, self.config)

        # 4. Create client
        self.data_system_client = AsyncTransferQueueClient(
            client_id="Trainer",
            controller_info=self.data_system_controller_info,
        )

        self.data_system_client.initialize_storage_manager(manager_type="YuanrongStorageManager", config=self.config)
        # Note: The client contains ZMQ objects. Currently, we cannot transmit the same client instance
        # to multiple places, as this will cause serialization errors in Ray.
        # Workaround: If you need to use a client in multiple Ray actors or processes, create a separate
        # AsyncTransferQueueClient instance for each actor/process instead of sharing or transmitting the same instance.
        return self.data_system_client

    def fit(self):
        for epoch in range(1):
            train_dataloader = 1
            for step in range(train_dataloader):
                input_ids = (
                    torch.tensor([[1, 2], [3, 4], [5, 6], [7, 8], [10, 11], [100, 111], [200, 222], [300, 333]])
                ) * (step + 1)
                input_ids_repeated = torch.repeat_interleave(input_ids, self.config.num_n_samples, dim=0)
                prompt_batch = TensorDict(
                    {"input_ids": input_ids_repeated, "attention_mask": input_ids_repeated},
                    batch_size=input_ids_repeated.size(0),
                )

                asyncio.run(self.data_system_client.async_put(data=prompt_batch, partition_id=f"train_{step}"))

                logger.info("demo put prompts ok! ")
                time.sleep(5)

                batch_meta = asyncio.run(
                    self.data_system_client.async_get_meta(
                        data_fields=["input_ids", "attention_mask"],
                        batch_size=self.config.global_batch_size * self.config.num_n_samples,
                        partition_id=f"train_{step}",
                        task_name="generate_sequences",
                    )
                )
                logger.info(f"demo get meta {batch_meta}")

                # Simulate calling the generate sequences task of the worker group
                if not self.config.async_rollout_mode:
                    batch_meta = self.actor_rollout_wg.actor_rollout_wg_generate_sequences(
                        batch_meta, self.data_system_client
                    )
                else:
                    batch_meta = self.async_rollout_manager.generate_sequences(batch_meta)
                log_prob_meta = asyncio.run(
                    self.data_system_client.async_get_meta(
                        data_fields=["input_ids", "attention_mask", "generate_sequences_ids"],
                        batch_size=self.config.global_batch_size * self.config.num_n_samples,
                        partition_id=f"train_{step}",
                        task_name="compute_old_log_prob",
                    )
                )
                logger.info(f"demo get log prob meta: {log_prob_meta}")

                # Simulate calling the compute old log prob task of the worker group
                old_log_prob_meta = self.actor_rollout_wg.actor_rollout_wg_compute_old_log_prob(
                    log_prob_meta, self.data_system_client
                )

                batch_meta = batch_meta.union(old_log_prob_meta)

                # Client notifies controller to clear data status, controller returns metadata;
                # Client then notifies the storage plane to clear based on metadata
                asyncio.run(self.data_system_client.async_clear(partition_id=f"train_{step}"))
                logger.info("clear ok! ")
        logger.info("demo done!")

        # Cleanup resources
        self.data_system_client.close()
        return batch_meta


if __name__ == "__main__":
    # NOTE: you may choose to set async_rollout_mode=True to test the async rollout mode that mimics
    # AgentLoopManager in verl
    config_str = """
      global_batch_size: 8
      num_global_batch: 1
      num_data_storage_units: 2
      async_rollout_mode: True
      rollout_agent_num_workers: 2
      num_n_samples: 2
      host: '127.0.0.1'
      port: 31511
      client_name: 'YuanrongStorageClient'
    """
    dict_conf = OmegaConf.create(config_str)

    trainer = Trainer(dict_conf)
    trainer.fit()
    
    ray.shutdown()
   
    print('demo finished!')
```
</details>


Note: If you want to use the NPU and achieve faster tensor access speed, please install `torch_npu` and specify the required resources in `ray.remote`:

```python
@ray.remote(num_cpus=1, resources={"NPU": 1})
class AsyncRolloutWorker:
```


## TODO
- [x]  Solve NPU-related reliability issues and improve the robustness of `YRStorageClient`.
- [x]  Test more non-tensor types.
- [x]  Conduct performance testing about npu tensors and cpu object.
- [x]  Integrate the entire TransferQueue to test.