### PR TITLE
[serialization] perf: use _internal_rpc_pickler and msgpack to speed up zmq msg serialization

### DIFF
--- a/recipe/simple_use_case/async_demo.py
+++ b/recipe/simple_use_case/async_demo.py
@@ -67,7 +67,7 @@ class ActorRolloutRefWorker:
             {
                 "generate_sequences_ids": output,
                 "non_tensor_data": torch.stack([NonTensorData("test_str") for _ in range(output.size(0))]),
-                "nested_tensor": torch.nested.as_nested_tensor([torch.randn(1, 2) for _ in range(output.size(0))]),
+                "nested_tensor": torch.nested.as_nested_tensor([torch.randn(1, 2) for _ in range(output.size(0))], layout=torch.jagged),
             },
             batch_size=output.size(0),
         )
@@ -119,7 +119,7 @@ class AsyncvLLMServer:
             {
                 "generate_sequences_ids": data,
                 "non_tensor_data": torch.stack([NonTensorData("test_str") for _ in range(data.size(0))]),
-                "nested_tensor": torch.nested.as_nested_tensor([torch.randn(1, 2) for _ in range(data.size(0))]),
+                "nested_tensor": torch.nested.as_nested_tensor([torch.randn(1, 2) for _ in range(data.size(0))], layout=torch.jagged),
             },
             batch_size=data.size(0),
         )

--- a/recipe/simple_use_case/async_demo.py
+++ b/recipe/simple_use_case/async_demo.py
@@ -67,7 +67,9 @@ class ActorRolloutRefWorker:
             {
                 "generate_sequences_ids": output,
                 "non_tensor_data": torch.stack([NonTensorData("test_str") for _ in range(output.size(0))]),
-                "nested_tensor": torch.nested.as_nested_tensor([torch.randn(1, 2) for _ in range(output.size(0))], layout=torch.jagged),
+                "nested_tensor": torch.nested.as_nested_tensor(
+                    [torch.randn(1, 2) for _ in range(output.size(0))], layout=torch.jagged
+                ),
             },
             batch_size=output.size(0),
         )
@@ -119,7 +121,9 @@ class AsyncvLLMServer:
             {
                 "generate_sequences_ids": data,
                 "non_tensor_data": torch.stack([NonTensorData("test_str") for _ in range(data.size(0))]),
-                "nested_tensor": torch.nested.as_nested_tensor([torch.randn(1, 2) for _ in range(data.size(0))], layout=torch.jagged),
+                "nested_tensor": torch.nested.as_nested_tensor(
+                    [torch.randn(1, 2) for _ in range(data.size(0))], layout=torch.jagged
+                ),
             },
             batch_size=data.size(0),
         )

--- a/recipe/simple_use_case/sync_demo.py
+++ b/recipe/simple_use_case/sync_demo.py
@@ -105,7 +105,9 @@ def actor_rollout_wg_generate_sequences(data_meta, data_system_client):
         {
             "generate_sequences_ids": output,
             "non_tensor_data": torch.stack([NonTensorData("test_str") for _ in range(output.size(0))]),
-            "nested_tensor": torch.nested.as_nested_tensor([torch.randn(1, 2) for _ in range(output.size(0))], layout=torch.jagged),
+            "nested_tensor": torch.nested.as_nested_tensor(
+                [torch.randn(1, 2) for _ in range(output.size(0))], layout=torch.jagged
+            ),
         },
         batch_size=output.size(0),
     )

--- a/recipe/simple_use_case/sync_demo.py
+++ b/recipe/simple_use_case/sync_demo.py
@@ -105,7 +105,7 @@ def actor_rollout_wg_generate_sequences(data_meta, data_system_client):
         {
             "generate_sequences_ids": output,
             "non_tensor_data": torch.stack([NonTensorData("test_str") for _ in range(output.size(0))]),
-            "nested_tensor": torch.nested.as_nested_tensor([torch.randn(1, 2) for _ in range(output.size(0))]),
+            "nested_tensor": torch.nested.as_nested_tensor([torch.randn(1, 2) for _ in range(output.size(0))], layout=torch.jagged),
         },
         batch_size=output.size(0),
     )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,7 +48,8 @@ TEST_DATA = TensorDict(
                 torch.tensor([-0.5, -1.2, -0.8]),
                 torch.tensor([-0.3, -1.5, -2.1, -0.9]),
                 torch.tensor([-1.1, -0.7]),
-            ]
+            ],
+            layout=torch.jagged,
         ),
         "prompt_text": ["Hello world!", "This is a longer sentence for testing", "Test case"],
     },
@@ -229,7 +230,7 @@ class MockStorage:
             if gathered_items:
                 all_tensors = all(isinstance(x, torch.Tensor) for x in gathered_items)
                 if all_tensors:
-                    result[field] = torch.nested.as_nested_tensor(gathered_items)
+                    result[field] = torch.nested.as_nested_tensor(gathered_items, layout=torch.jagged)
                 else:
                     result[field] = NonTensorStack(*gathered_items)
 

--- a/tests/test_serial_utils_on_cpu.py
+++ b/tests/test_serial_utils_on_cpu.py
@@ -19,13 +19,11 @@ import pytest
 import torch
 from tensordict import TensorDict
 
-
 # Import your classes here
 parent_dir = Path(__file__).resolve().parent.parent
 sys.path.append(str(parent_dir))
 
 from transfer_queue.utils.serial_utils import MsgpackDecoder, MsgpackEncoder  # noqa: E402
-
 
 
 @pytest.mark.parametrize(
@@ -58,12 +56,14 @@ def test_zmq_msg_serialization():
         body={
             "data": TensorDict(
                 {
-                    "nested_tensor": torch.nested.as_nested_tensor([torch.randn(2, 3), torch.randn(2, 4)], layout=torch.jagged),
+                    "nested_tensor": torch.nested.as_nested_tensor(
+                        [torch.randn(2, 3), torch.randn(2, 4)], layout=torch.jagged
+                    ),
                     "numpy_array": torch.randn(2, 2).numpy(),
                 },
                 batch_size=2,
             )
-        }
+        },
     )
     encoded_msg = msg.serialize()
     decoded_msg = ZMQMessage.deserialize(encoded_msg)

--- a/tests/test_serial_utils_on_cpu.py
+++ b/tests/test_serial_utils_on_cpu.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 import torch
+from tensordict import TensorDict
 
 
 # Import your classes here
@@ -24,6 +25,7 @@ parent_dir = Path(__file__).resolve().parent.parent
 sys.path.append(str(parent_dir))
 
 from transfer_queue.utils.serial_utils import MsgpackDecoder, MsgpackEncoder  # noqa: E402
+
 
 
 @pytest.mark.parametrize(
@@ -43,13 +45,32 @@ def test_tensor_serialization(dtype):
     deserialized = decoder.decode(serialized)
     assert torch.allclose(tensor, deserialized)
 
-    vocab_size = 128
-    a = torch.randint(low=0, high=vocab_size, size=(11,))
-    b = torch.randint(low=0, high=vocab_size, size=(13,))
-    input_ids = [a, b]
-    input_ids = torch.nested.as_nested_tensor(input_ids, layout=torch.jagged, dtype=dtype)
 
-    input_ids_serialized = encoder.encode(input_ids)
-    input_ids_deserialized = decoder.decode(input_ids_serialized)
-    for i in range(len(input_ids.unbind())):
-        assert torch.allclose(input_ids[i], input_ids_deserialized[i])
+def test_zmq_msg_serialization():
+    from transfer_queue.utils.zmq_utils import ZMQMessage, ZMQRequestType
+
+    msg = ZMQMessage(
+        request_type=ZMQRequestType.PUT_DATA,
+        sender_id="test_sender",
+        receiver_id="test_receiver",
+        request_id="test_request",
+        timestamp="test_timestamp",
+        body={
+            "data": TensorDict(
+                {
+                    "nested_tensor": torch.nested.as_nested_tensor([torch.randn(2, 3), torch.randn(2, 4)], layout=torch.jagged),
+                    "numpy_array": torch.randn(2, 2).numpy(),
+                },
+                batch_size=2,
+            )
+        }
+    )
+    encoded_msg = msg.serialize()
+    decoded_msg = ZMQMessage.deserialize(encoded_msg)
+    assert decoded_msg.request_type == msg.request_type
+    assert torch.allclose(decoded_msg.body["data"]["numpy_array"], msg.body["data"]["numpy_array"])
+    for i in range(len(msg.body["data"]["nested_tensor"].unbind())):
+        assert torch.allclose(
+            decoded_msg.body["data"]["nested_tensor"][i],
+            msg.body["data"]["nested_tensor"][i],
+        )

--- a/tests/test_serial_utils_on_cpu.py
+++ b/tests/test_serial_utils_on_cpu.py
@@ -15,50 +15,15 @@
 import sys
 from pathlib import Path
 
-import numpy as np
 import pytest
-import tensordict
 import torch
-from tensordict import NonTensorData, NonTensorStack, TensorDict
+
 
 # Import your classes here
 parent_dir = Path(__file__).resolve().parent.parent
 sys.path.append(str(parent_dir))
 
 from transfer_queue.utils.serial_utils import MsgpackDecoder, MsgpackEncoder  # noqa: E402
-
-
-def get_tensordict(tensor_dict: dict[str, torch.Tensor | list], non_tensor_dict: dict = None) -> TensorDict:
-    if non_tensor_dict is None:
-        non_tensor_dict = {}
-
-    batch_size = None
-
-    for key, val in tensor_dict.items():
-        if isinstance(val, list):
-            for v in val:
-                assert not isinstance(v, torch.Tensor), (
-                    "Passing a list makes the data NonTensorStack, "
-                    "which doesn't support torch.Tensor. Please convert to numpy first"
-                )
-
-        assert isinstance(val, torch.Tensor | list)
-
-        if batch_size is None:
-            batch_size = len(val)
-        else:
-            assert len(val) == batch_size
-
-    if batch_size is None:
-        batch_size = []
-    else:
-        batch_size = [batch_size]
-
-    for key, val in non_tensor_dict.items():
-        assert key not in tensor_dict
-        tensor_dict[key] = NonTensorData(val)
-
-    return TensorDict(source=tensor_dict, batch_size=batch_size)
 
 
 @pytest.mark.parametrize(
@@ -87,116 +52,4 @@ def test_tensor_serialization(dtype):
     input_ids_serialized = encoder.encode(input_ids)
     input_ids_deserialized = decoder.decode(input_ids_serialized)
     for i in range(len(input_ids.unbind())):
-        assert torch.allclose(input_ids[0], input_ids_deserialized[0])
-
-
-def test_tensordict_serialization_with_nontensor():
-    encoder = MsgpackEncoder()
-    decoder = MsgpackDecoder(TensorDict)
-
-    obs = torch.randn(100, 10)
-    data1 = {"obs": obs, "act": torch.randn(100, 3), "data_sources": ["gsm8k"] * 100}
-    data1 = get_tensordict(tensor_dict=data1)
-
-    serialized = encoder.encode(data1)
-    deserialized = decoder.decode(serialized)
-
-    assert deserialized.keys() == data1.keys()
-    assert deserialized.batch_size[0] == 100
-    assert isinstance(deserialized.get("data_sources"), NonTensorStack)
-    for k, v in data1.items():
-        if isinstance(v, torch.Tensor):
-            assert torch.allclose(deserialized[k], v)
-        elif isinstance(v, NonTensorStack):
-            assert deserialized[k] == data1[k]
-
-
-def test_tensordict_serialization_with_images():
-    # each sample contains a sequence with multiple images of different sizes
-    vocab_size = 128
-    a = torch.randint(low=0, high=vocab_size, size=(11,))
-    b = torch.randint(low=0, high=vocab_size, size=(13,))
-    input_ids = [a, b]
-    input_ids = torch.nested.as_nested_tensor(input_ids, layout=torch.jagged)
-
-    a_images = [
-        torch.randint(low=0, high=255, size=(3, 256, 256), dtype=torch.uint8).numpy(),
-        torch.randint(low=0, high=255, size=(3, 128, 128), dtype=torch.uint8).numpy(),
-    ]
-    b_images = [
-        torch.randint(low=0, high=255, size=(3, 256, 256), dtype=torch.uint8).numpy(),
-        torch.randint(low=0, high=255, size=(3, 128, 128), dtype=torch.uint8).numpy(),
-        torch.randint(low=0, high=255, size=(3, 64, 64), dtype=torch.uint8).numpy(),
-    ]
-
-    images = [a_images, b_images]
-
-    data = get_tensordict({"input_ids": input_ids, "images": images})
-
-    encoder = MsgpackEncoder()
-    decoder = MsgpackDecoder(TensorDict)
-
-    serialized = encoder.encode(data)
-    deserialized = decoder.decode(serialized)
-
-    assert np.all(np.equal(deserialized[0]["images"][0], a_images[0]))
-    assert torch.all(torch.eq(deserialized[0]["input_ids"], a))
-
-
-# Copied from https://github.com/volcengine/verl/blob/33edd95e13c72b9494585765b5fedc679fd73923/tests/test_protocol_v2_on_cpu.py#L119
-def test_tensordict_with_packing():
-    vocab_size = 128
-    a = torch.randint(low=0, high=vocab_size, size=(11,))
-    b = torch.randint(low=0, high=vocab_size, size=(13,))
-    input_ids = [a, b]
-    input_ids = torch.nested.as_nested_tensor(input_ids, layout=torch.jagged)
-
-    data = get_tensordict({"input_ids": input_ids})
-    encoder = MsgpackEncoder()
-    decoder = MsgpackDecoder(TensorDict)
-    deserialized_data = decoder.decode(encoder.encode(data))
-
-    # test cu_seqlens
-    cu_seqlens = torch.tensor([0, 11, 24])
-    assert torch.all(torch.eq(cu_seqlens, deserialized_data["input_ids"].offsets()))
-
-    # test index
-    assert torch.all(torch.eq(deserialized_data["input_ids"][0], a))
-    assert torch.all(torch.eq(deserialized_data["input_ids"][1], b))
-
-    assert torch.all(torch.eq(deserialized_data[0]["input_ids"], a))
-    assert torch.all(torch.eq(deserialized_data[1]["input_ids"], b))
-
-    data_lst = deserialized_data.chunk(2)
-
-    assert torch.all(torch.eq(data_lst[0]["input_ids"][0], a))
-    assert torch.all(torch.eq(data_lst[1]["input_ids"][0], b))
-
-
-def test_nested_tensordict_serialization():
-    td1 = tensordict.TensorDict({"a": torch.randn(2, 3), "b": torch.randn(2, 4)}, batch_size=[2])
-
-    td2 = tensordict.TensorDict({"c": torch.randn(2, 5), "d": torch.randn(2, 6)}, batch_size=[2])
-
-    td = tensordict.TensorDict({"part1": td1, "part2": td2, "e": torch.randn(2, 7)}, batch_size=[2])
-
-    encoder = MsgpackEncoder()
-    decoder = MsgpackDecoder(TensorDict)
-    deserialized_td = decoder.decode(encoder.encode(td))
-
-    assert isinstance(deserialized_td, tensordict.TensorDict)
-    assert set(deserialized_td.keys()) == set(td.keys())
-    assert isinstance(deserialized_td["part1"], tensordict.TensorDict)
-    assert isinstance(deserialized_td["part2"], tensordict.TensorDict)
-
-    assert set(deserialized_td["part1"].keys()) == set(td1.keys())
-    assert set(deserialized_td["part2"].keys()) == set(td2.keys())
-
-    for key in td.keys():
-        if isinstance(td[key], tensordict.TensorDict):
-            for inner_key in td[key].keys():
-                assert torch.allclose(deserialized_td[key][inner_key], td[key][inner_key]), (
-                    f"Values for key '{key}.{inner_key}' do not match"
-                )
-        else:
-            assert torch.allclose(deserialized_td[key], td[key]), f"Values for key '{key}' do not match"
+        assert torch.allclose(input_ids[i], input_ids_deserialized[i])

--- a/transfer_queue/storage/managers/simple_backend_manager.py
+++ b/transfer_queue/storage/managers/simple_backend_manager.py
@@ -211,7 +211,7 @@ class AsyncSimpleStorageManager(TransferQueueStorageManager):
         tensordict_data = TensorDict(
             {
                 field: (
-                    torch.nested.as_nested_tensor(transfer_data["field_data"][field])
+                    torch.nested.as_nested_tensor(transfer_data["field_data"][field], layout=torch.jagged)
                     if transfer_data["field_data"][field]
                     and all(isinstance(x, torch.Tensor) for x in transfer_data["field_data"][field])
                     else NonTensorStack(*transfer_data["field_data"][field])
@@ -287,12 +287,12 @@ class AsyncSimpleStorageManager(TransferQueueStorageManager):
         with limit_pytorch_auto_parallel_threads():
             tensor_data = {
                 field: (
-                    torch.stack(torch.nested.as_nested_tensor(v).unbind())
+                    torch.stack(torch.nested.as_nested_tensor(v, layout=torch.jagged).unbind())
                     if v
                     and all(isinstance(item, torch.Tensor) for item in v)
                     and all(item.shape == v[0].shape for item in v)
                     else (
-                        torch.nested.as_nested_tensor(v)
+                        torch.nested.as_nested_tensor(v, layout=torch.jagged)
                         if v and all(isinstance(item, torch.Tensor) for item in v)
                         else NonTensorStack(*v)
                     )

--- a/transfer_queue/storage/simple_backend.py
+++ b/transfer_queue/storage/simple_backend.py
@@ -96,7 +96,7 @@ class StorageUnitData:
                 if gathered_items:
                     all_tensors = all(isinstance(x, torch.Tensor) for x in gathered_items)
                     if all_tensors:
-                        result[field] = torch.nested.as_nested_tensor(gathered_items)
+                        result[field] = torch.nested.as_nested_tensor(gathered_items, layout=torch.jagged)
                     else:
                         result[field] = NonTensorStack(*gathered_items)
 

--- a/transfer_queue/utils/serial_utils.py
+++ b/transfer_queue/utils/serial_utils.py
@@ -92,33 +92,7 @@ class MsgpackEncoder:
 
         return msgpack.Ext(CUSTOM_TYPE_PICKLE, pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL))
 
-    def _encode_tensordict(self, obj: TensorDict) -> tuple[tuple[int, ...], Optional[str], dict[str, tuple[str, Any]]]:
-        assert self.aux_buffers is not None
-        encoded_items: dict[str, tuple[str, Any]] = {}
-        for k, v in obj.items():
-            if isinstance(v, torch.Tensor):
-                encoded_items[k] = ("tensor", self._encode_tensor(v))
-            # elif isinstance(v, NonTensorStack):
-            #     encoded_items[k] = ("non_tensor_stack", self._encode_non_tensor_stack(v))
-            elif isinstance(v, NonTensorData):
-                encoded_items[k] = ("non_tensor_data", self._encode_non_tensor_data(v))
-            else:
-                data = len(self.aux_buffers)
-                self.aux_buffers.append(pickle.dumps(v, protocol=pickle.HIGHEST_PROTOCOL))
-                encoded_items[k] = ("other", data)
-        batch_size = tuple(obj.batch_size)
-        device = str(obj.device) if obj.device is not None else None
-        return batch_size, device, encoded_items
-
     def _encode_tensor(self, obj: torch.Tensor) -> tuple[str, list[tensorenc]] | tensorenc:
-        if not obj.is_nested:
-            return self._encode_single_tensor(obj)
-        else:
-            layout = str(obj.layout).removeprefix("torch.")
-            data = [self._encode_single_tensor(tensor) for tensor in obj.unbind()]
-            return layout, data
-
-    def _encode_single_tensor(self, obj: torch.Tensor) -> tensorenc:
         assert self.aux_buffers is not None
         # view the tensor as a contiguous 1D array of bytes
         arr = obj.flatten().contiguous().view(torch.uint8).numpy()
@@ -131,14 +105,6 @@ class MsgpackEncoder:
             self.aux_buffers.append(arr.data)
         dtype = str(obj.dtype).removeprefix("torch.")
         return dtype, obj.shape, data
-
-    def _encode_non_tensor_data(self, obj: NonTensorData) -> tuple[tuple[int, ...], Optional[str], int]:
-        assert self.aux_buffers is not None
-        batch_size = tuple(obj.batch_size)
-        device = str(obj.device) if obj.device is not None else None
-        data = len(self.aux_buffers)
-        self.aux_buffers.append(pickle.dumps(obj.data, protocol=pickle.HIGHEST_PROTOCOL))
-        return batch_size, device, data
 
 
 class MsgpackDecoder:
@@ -166,46 +132,11 @@ class MsgpackDecoder:
     def dec_hook(self, t: type, obj: Any) -> Any:
         # Given native types in `obj`, convert to type `t`.
         if isclass(t):
-            if issubclass(t, TensorDict):
-                return self._decode_tensordict(obj)
             if issubclass(t, torch.Tensor):
                 return self._decode_tensor(obj)
         return obj
 
-    def _decode_tensordict(self, arr: Any) -> TensorDict:
-        batch_size, device, encoded_items = arr
-        decoded_items: dict[str, Any] = {}
-
-        for k, (v_type, v) in encoded_items.items():
-            if v_type == "tensor":
-                decoded_items[k] = self._decode_tensor(v)
-            # elif v_type == "non_tensor_stack":
-            #     decoded_items[k] = self._decode_non_tensor_stack(v)
-            elif v_type == "non_tensor_data":
-                decoded_items[k] = self._decode_non_tensor_data(v)
-            elif v_type == "other":
-                decoded_items[k] = pickle.loads(self.aux_buffers[v])
-
-        batch_size = torch.Size(batch_size)
-        torch_device = torch.device(device) if device is not None else None
-
-        return TensorDict(source=decoded_items, batch_size=batch_size, device=torch_device)
-
     def _decode_tensor(self, arr: Any) -> torch.Tensor:
-        if len(arr) == 3:
-            # decode single tensor
-            return self._decode_single_tensor(arr)
-        elif len(arr) == 2:
-            # decode nested tensor
-            layout, data = arr
-            torch_layout = getattr(torch, layout)
-            return torch.nested.as_nested_tensor(
-                [self._decode_single_tensor(tensor) for tensor in data], layout=torch_layout
-            )
-        else:
-            raise ValueError(f"Invalid tensor encoding format, expected length 2 or 3, got {len(arr)}")
-
-    def _decode_single_tensor(self, arr: Any) -> torch.Tensor:
         dtype, shape, data = arr
         # Copy from inline representation, to decouple the memory storage
         # of the message from the original buffer. And also make Torch
@@ -220,14 +151,6 @@ class MsgpackDecoder:
         arr = torch.frombuffer(buffer, dtype=torch.uint8)
         # Convert back to proper shape & type
         return arr.view(torch_dtype).view(shape)
-
-    def _decode_non_tensor_data(self, arr: Any) -> NonTensorData:
-        batch_size, device, data = arr
-        buffer = self.aux_buffers[data]
-        batch_size = torch.Size(batch_size)
-        torch_device = torch.device(device) if device is not None else None
-        non_tensor_data = pickle.loads(buffer)
-        return NonTensorData(data=non_tensor_data, batch_size=batch_size, device=torch_device)
 
     def ext_hook(self, code: int, data: memoryview) -> Any:
         if code == CUSTOM_TYPE_RAW_VIEW:

--- a/transfer_queue/utils/serial_utils.py
+++ b/transfer_queue/utils/serial_utils.py
@@ -26,7 +26,6 @@ import cloudpickle
 import torch
 import zmq
 from msgspec import msgpack
-from tensordict import NonTensorData, TensorDict
 
 TQ_MSGPACK_ZERO_COPY_THRESHOLD = int(os.environ.get("TQ_MSGPACK_ZERO_COPY_THRESHOLD", 256))
 CUSTOM_TYPE_PICKLE = 1
@@ -79,9 +78,6 @@ class MsgpackEncoder:
             self.aux_buffers = None
 
     def enc_hook(self, obj: Any) -> Any:
-        if isinstance(obj, TensorDict):
-            return self._encode_tensordict(obj)
-
         if isinstance(obj, torch.Tensor):
             return self._encode_tensor(obj)
 

--- a/transfer_queue/utils/zmq_utils.py
+++ b/transfer_queue/utils/zmq_utils.py
@@ -19,13 +19,20 @@ from dataclasses import dataclass
 from typing import Any, Optional
 from uuid import uuid4
 
+import torch
 import psutil
 import zmq
+from torch.distributed.rpc.internal import _internal_rpc_pickler
 
 from transfer_queue.utils.utils import (
     ExplicitEnum,
     TransferQueueRole,
 )
+from transfer_queue.utils.serial_utils import MsgpackEncoder, MsgpackDecoder
+
+
+_encoder = MsgpackEncoder()
+_decoder = MsgpackDecoder(torch.Tensor)
 
 
 class ZMQRequestType(ExplicitEnum):
@@ -115,20 +122,23 @@ class ZMQMessage:
 
     def serialize(self) -> bytes:
         """Using pickle to serialize ZMQMessage objects"""
-        return pickle.dumps(self)
+        pickled_bytes, tensors = _internal_rpc_pickler.serialize(self)
+        if len(tensors) > 0:
+            serialized_tensors = [None] * len(tensors)
+            for i, tensor in enumerate(tensors):
+                serialized_tensors[i] = _encoder.encode(tensor)
+        else:
+            serialized_tensors = []
+        return pickled_bytes, serialized_tensors
 
     @classmethod
-    def deserialize(cls, data: bytes | list[bytes]):
+    def deserialize(cls, data: tuple[bytes, list[bytes]]):
         """Using pickle to deserialize ZMQMessage objects"""
-        if isinstance(data, list):
-            # Process multiple byte streams by deserializing each in sequence
-            result = []
-            for d in data:
-                result.append(pickle.loads(d))
-            return result
-        else:
-            # Single byte stream case
-            return pickle.loads(data)
+        pickled_bytes, serialized_tensors = data
+        tensors = [None] * len(serialized_tensors)
+        for i, serialized_tensor in enumerate(serialized_tensors):
+            tensors[i] = _decoder.decode(serialized_tensor)
+        return _internal_rpc_pickler.deserialize(pickled_bytes, tensors)
 
 
 def get_free_port() -> str:

--- a/transfer_queue/utils/zmq_utils.py
+++ b/transfer_queue/utils/zmq_utils.py
@@ -19,18 +19,23 @@ from dataclasses import dataclass
 from typing import Any, Optional
 from uuid import uuid4
 
-import torch
-import psutil
 import msgpack
+import psutil
+import torch
 import zmq
-from torch.distributed.rpc.internal import _internal_rpc_pickler
 
+try:
+    from torch.distributed.rpc.internal import _internal_rpc_pickler
+
+    USE_PRC_PICKLER = True
+except ImportError:
+    USE_PRC_PICKLER = False
+
+from transfer_queue.utils.serial_utils import MsgpackDecoder, MsgpackEncoder
 from transfer_queue.utils.utils import (
     ExplicitEnum,
     TransferQueueRole,
 )
-from transfer_queue.utils.serial_utils import MsgpackEncoder, MsgpackDecoder
-
 
 _encoder = MsgpackEncoder()
 _decoder = MsgpackDecoder(torch.Tensor)
@@ -123,24 +128,30 @@ class ZMQMessage:
 
     def serialize(self) -> bytes:
         """Using pickle to serialize ZMQMessage objects"""
-        pickled_bytes, tensors = _internal_rpc_pickler.serialize(self)
-        if len(tensors) > 0:
-            serialized_tensors = [None] * len(tensors)
-            for i, tensor in enumerate(tensors):
-                serialized_tensors[i] = _encoder.encode(tensor)
-        else:
-            serialized_tensors = []
+        if USE_PRC_PICKLER:
+            pickled_bytes, tensors = _internal_rpc_pickler.serialize(self)
+            if len(tensors) > 0:
+                serialized_tensors = [None] * len(tensors)
+                for i, tensor in enumerate(tensors):
+                    serialized_tensors[i] = _encoder.encode(tensor)  # type: ignore[call-overload]
+            else:
+                serialized_tensors = []
 
-        return msgpack.packb((pickled_bytes, serialized_tensors), use_bin_type=True)
+            return msgpack.packb((pickled_bytes, serialized_tensors), use_bin_type=True)
+        else:
+            return pickle.dumps(self)
 
     @classmethod
     def deserialize(cls, data: bytes) -> "ZMQMessage":
         """Using pickle to deserialize ZMQMessage objects"""
-        pickled_bytes, serialized_tensors = msgpack.unpackb(data, raw=False)
-        tensors = [None] * len(serialized_tensors)
-        for i, serialized_tensor in enumerate(serialized_tensors):
-            tensors[i] = _decoder.decode(serialized_tensor)
-        return _internal_rpc_pickler.deserialize(pickled_bytes, tensors)
+        if USE_PRC_PICKLER:
+            pickled_bytes, serialized_tensors = msgpack.unpackb(data, raw=False)
+            tensors = [None] * len(serialized_tensors)
+            for i, serialized_tensor in enumerate(serialized_tensors):
+                tensors[i] = _decoder.decode(serialized_tensor)
+            return _internal_rpc_pickler.deserialize(pickled_bytes, tensors)
+        else:
+            pickle.loads(data)
 
 
 def get_free_port() -> str:

--- a/transfer_queue/utils/zmq_utils.py
+++ b/transfer_queue/utils/zmq_utils.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 
 import torch
 import psutil
+import msgpack
 import zmq
 from torch.distributed.rpc.internal import _internal_rpc_pickler
 
@@ -129,12 +130,13 @@ class ZMQMessage:
                 serialized_tensors[i] = _encoder.encode(tensor)
         else:
             serialized_tensors = []
-        return pickled_bytes, serialized_tensors
+
+        return msgpack.packb((pickled_bytes, serialized_tensors), use_bin_type=True)
 
     @classmethod
-    def deserialize(cls, data: tuple[bytes, list[bytes]]):
+    def deserialize(cls, data: bytes) -> "ZMQMessage":
         """Using pickle to deserialize ZMQMessage objects"""
-        pickled_bytes, serialized_tensors = data
+        pickled_bytes, serialized_tensors = msgpack.unpackb(data, raw=False)
         tensors = [None] * len(serialized_tensors)
         for i, serialized_tensor in enumerate(serialized_tensors):
             tensors[i] = _decoder.decode(serialized_tensor)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized nested-tensor handling to a jagged layout across storage and transfer flows.
  * Simplified serialization: removed tensordict/non-tensor branches and streamlined tensor encoding/decoding.
  * Introduced a msgpack-based serialization path with dedicated encoder/decoder and a single-bytes message payload handling; message deserialization public signature updated.

* **Tests**
  * Replaced broad serialization suites with a focused end-to-end message serialization/deserialization test; obsolete helpers removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->