### PR TITLE
[Fix] More robust BatchMeta chunk & concat

### DIFF
--- a/transfer_queue/metadata.py
+++ b/transfer_queue/metadata.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("TQ_LOGGING_LEVEL", logging.WARNING))
 
 
+# TODO: Add UT for metadata operations
 @dataclass
 class FieldMeta:
     """Records the metadata of a single data field (name, dtype, shape, etc.)."""
@@ -283,7 +284,7 @@ class BatchMeta:
         return chunk_list
 
     @classmethod
-    def concat(cls, data: list["BatchMeta"], validate: bool = True) -> Optional["BatchMeta"]:
+    def concat(cls, data: list["BatchMeta"], validate: bool = True) -> "BatchMeta":
         """
         Concatenate multiple BatchMeta chunks into one large batch.
 
@@ -298,15 +299,15 @@ class BatchMeta:
             ValueError: If validation fails (e.g., field names do not match)
         """
         if not data:
-            logger.warning("Try to concat empty BatchMeta chunks. Returning None.")
-            return None
+            logger.warning("Try to concat empty BatchMeta chunks. Returning empty BatchMeta.")
+            return BatchMeta(samples=[], extra_info={})
 
         # skip empty chunks
         data = [chunk for chunk in data if chunk and len(chunk.samples) > 0]
 
         if len(data) == 0:
-            logger.warning("No valid BatchMeta chunks to concatenate. Returning None.")
-            return None
+            logger.warning("No valid BatchMeta chunks to concatenate. Returning empty BatchMeta.")
+            return BatchMeta(samples=[], extra_info={})
 
         if validate:
             base_fields = data[0].field_names

--- a/transfer_queue/metadata.py
+++ b/transfer_queue/metadata.py
@@ -261,6 +261,12 @@ class BatchMeta:
         chunk_list = []
         n = len(self.samples)
 
+        if n < chunks:
+            logger.warning(
+                f"Chunk size {chunks} > number of samples in BatchMeta {n}, this will return some "
+                f"empty BatchMeta chunks."
+            )
+
         # Calculate the base size and remainder of each chunk
         base_size = n // chunks
         remainder = n % chunks
@@ -292,6 +298,14 @@ class BatchMeta:
             ValueError: If validation fails (e.g., field names do not match)
         """
         if not data:
+            logger.warning("Try to concat empty BatchMeta chunks. Returning None.")
+            return None
+
+        # skip empty chunks
+        data = [chunk for chunk in data if chunk and len(chunk.samples) > 0]
+
+        if len(data) == 0:
+            logger.warning("No valid BatchMeta chunks to concatenate. Returning None.")
             return None
 
         if validate:


### PR DESCRIPTION
## Background

In real-world usage, we may need to chunk `BatchMeta` to dispatch different samples to different workers, such as https://github.com/volcengine/verl/blob/main/verl/experimental/agent_loop/agent_loop.py#L830.

When number of workers > number of samples in `BatchMeta`, empty `BatchMeta` will be returned to the user. This may lead to unexpected error.

## Solution
1. We add a warning when the user try to chunk `BatchMeta` into pieces that are larger than number of samples.
```python3
    # In metadata.py
    def chunk(self, chunks: int) -> list["BatchMeta"]:
        """
        Split this batch into smaller chunks.

        Args:
            chunks: number of chunks

        Return:
            List of smaller BatchMeta chunks
        """
        chunk_list = []
        n = len(self.samples)

        if n < chunks:
            logger.warning(
                f"Chunk size {chunks} > number of samples in BatchMeta {n}, this will return some "
                f"empty BatchMeta chunks."
            )
```
2. We officially support concat empty `BatchMeta` to make the code more robust when the above scenario happens.
```python3
    @classmethod
    def concat(cls, data: list["BatchMeta"], validate: bool = True) -> Optional["BatchMeta"]:
        """
        Concatenate multiple BatchMeta chunks into one large batch.

        Args:
            data: List of BatchMeta chunks to concatenate
            validate: Whether to validate concatenation conditions

        Returns:
            Concatenated BatchMeta

        Raises:
            ValueError: If validation fails (e.g., field names do not match)
        """
        if not data:
            logger.warning("Try to concat empty BatchMeta chunks. Returning None.")
            return None

        # skip empty chunks
        data = [chunk for chunk in data if chunk and len(chunk.samples) > 0]

        if len(data) == 0:
            logger.warning("No valid BatchMeta chunks to concatenate. Returning None.")
            return None
``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced batch processing to gracefully handle empty or undersized batches without errors.
  * Added warnings to alert users when batch operations may produce incomplete chunks or require filtered data processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->