### PR TITLE
[Feat] Add select_fields for BatchMeta & SampleMeta

### DIFF
--- a/tests/test_controller_data_partitions.py
+++ b/tests/test_controller_data_partitions.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The TransferQueue Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
 import sys

--- a/tests/test_kv_storage_manager.py
+++ b/tests/test_kv_storage_manager.py
@@ -1,14 +1,30 @@
+# Copyright 2025 The TransferQueue Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
 import unittest
+from pathlib import Path
 
 import torch
 from tensordict import TensorDict
 
-from transfer_queue.metadata import (
-    BatchMeta,
-    FieldMeta,
-    SampleMeta,
-)
-from transfer_queue.storage.managers.base import KVStorageManager
+# Setup path
+parent_dir = Path(__file__).resolve().parent.parent
+sys.path.append(str(parent_dir))
+
+from transfer_queue.metadata import BatchMeta, FieldMeta, SampleMeta  # noqa: E402
+from transfer_queue.storage.managers.base import KVStorageManager  # noqa: E402
 
 
 class Test(unittest.TestCase):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,447 @@
+# Copyright 2025 The TransferQueue Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for TransferQueue metadata module - Learning Examples."""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+from tensordict import TensorDict
+from tensordict.tensorclass import NonTensorStack
+
+# Setup path
+parent_dir = Path(__file__).resolve().parent.parent
+sys.path.append(str(parent_dir))
+
+from transfer_queue.metadata import BatchMeta, FieldMeta, SampleMeta  # noqa: E402
+from transfer_queue.utils.utils import ProductionStatus  # noqa: E402
+
+
+class TestFieldMeta:
+    """FieldMeta learning examples."""
+
+    def test_field_meta_is_ready(self):
+        """Test the is_ready property based on production status."""
+        field_ready = FieldMeta(
+            name="test_field", dtype=torch.float32, shape=(2, 3), production_status=ProductionStatus.READY_FOR_CONSUME
+        )
+        assert field_ready.is_ready is True
+
+        field_not_ready = FieldMeta(
+            name="test_field", dtype=torch.float32, shape=(2, 3), production_status=ProductionStatus.NOT_PRODUCED
+        )
+        assert field_not_ready.is_ready is False
+
+
+class TestSampleMeta:
+    """SampleMeta learning examples."""
+
+    def test_sample_meta_union(self):
+        """Example: Union fields from two samples with matching global indexes."""
+        # Create first sample
+        fields1 = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+        }
+        sample1 = SampleMeta(partition_id="partition_0", global_index=0, fields=fields1)
+
+        # Create second sample with additional fields
+        fields2 = {
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+            "field3": FieldMeta(name="field3", dtype=torch.bool, shape=(4,)),
+        }
+        sample2 = SampleMeta(partition_id="partition_0", global_index=0, fields=fields2)
+
+        # Union samples
+        result = sample1.union(sample2)
+
+        # Result contains all fields from both samples
+        assert "field1" in result.fields
+        assert "field2" in result.fields  # From sample2
+        assert "field3" in result.fields
+
+    def test_sample_meta_union_validation_error(self):
+        """Example: Union validation catches mismatched global indexes."""
+        sample1 = SampleMeta(
+            partition_id="partition_0",
+            global_index=0,
+            fields={"field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,))},
+        )
+
+        sample2 = SampleMeta(
+            partition_id="partition_0",
+            global_index=1,  # Different global index
+            fields={"field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,))},
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            sample1.union(sample2, validate=True)
+        assert "Global indexes" in str(exc_info.value)
+
+    def test_sample_meta_add_fields(self):
+        """Example: Add new fields to a sample."""
+        initial_fields = {
+            "field1": FieldMeta(
+                name="field1", dtype=torch.float32, shape=(2,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+        sample = SampleMeta(partition_id="partition_0", global_index=0, fields=initial_fields)
+
+        new_fields = {
+            "field2": FieldMeta(
+                name="field2", dtype=torch.int64, shape=(3,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+        sample.add_fields(new_fields)
+
+        assert "field1" in sample.fields
+        assert "field2" in sample.fields
+        assert sample.is_ready is True
+
+
+class TestBatchMeta:
+    """BatchMeta learning examples - Core Operations."""
+
+    def test_batch_meta_chunk(self):
+        """Example: Split a batch into multiple chunks."""
+        fields = {
+            "test_field": FieldMeta(
+                name="test_field", dtype=torch.float32, shape=(2,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+        samples = [SampleMeta(partition_id="partition_0", global_index=i, fields=fields) for i in range(10)]
+        batch = BatchMeta(samples=samples)
+
+        # Chunk into 3 parts
+        chunks = batch.chunk(3)
+
+        assert len(chunks) == 3
+        assert len(chunks[0]) == 4  # First chunk gets extra element
+        assert len(chunks[1]) == 3
+        assert len(chunks[2]) == 3
+
+    def test_batch_meta_concat(self):
+        """Example: Concatenate multiple batches."""
+        fields = {
+            "test_field": FieldMeta(
+                name="test_field", dtype=torch.float32, shape=(2,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+
+        # Create two batches
+        batch1 = BatchMeta(
+            samples=[
+                SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+                SampleMeta(partition_id="partition_0", global_index=1, fields=fields),
+            ]
+        )
+
+        batch2 = BatchMeta(
+            samples=[
+                SampleMeta(partition_id="partition_0", global_index=2, fields=fields),
+                SampleMeta(partition_id="partition_0", global_index=3, fields=fields),
+            ]
+        )
+
+        # Concatenate batches
+        result = BatchMeta.concat([batch1, batch2])
+
+        assert len(result) == 4
+        assert result.global_indexes == [0, 1, 2, 3]
+
+    def test_batch_meta_concat_with_tensor_extra_info(self):
+        """Example: Concat handles tensor extra_info by concatenating along dim=0."""
+        fields = {
+            "test_field": FieldMeta(
+                name="test_field", dtype=torch.float32, shape=(2,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+
+        batch1 = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=0, fields=fields)])
+        batch1.extra_info["tensor"] = torch.randn(3, 4)
+        batch1.extra_info["scalar"] = torch.tensor(1.0)
+
+        batch2 = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=1, fields=fields)])
+        batch2.extra_info["tensor"] = torch.randn(3, 4)
+        batch2.extra_info["scalar"] = torch.tensor(2.0)
+
+        result = BatchMeta.concat([batch1, batch2])
+
+        # Tensors are concatenated along dim=0
+        assert result.extra_info["tensor"].shape == (6, 4)
+        # Scalars are stacked
+        assert result.extra_info["scalar"].shape == (2,)
+
+    def test_batch_meta_concat_with_non_tensor_stack(self):
+        """Example: Concat handles NonTensorStack extra_info."""
+        fields = {
+            "test_field": FieldMeta(
+                name="test_field", dtype=torch.float32, shape=(2,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+
+        batch1 = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=0, fields=fields)])
+        batch1.extra_info["non_tensor"] = NonTensorStack(1, 2, 3)
+
+        batch2 = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=1, fields=fields)])
+        batch2.extra_info["non_tensor"] = NonTensorStack(4, 5, 6)
+
+        result = BatchMeta.concat([batch1, batch2])
+
+        # NonTensorStack is stacked
+        assert isinstance(result.extra_info["non_tensor"], NonTensorStack)
+        assert result.extra_info["non_tensor"].batch_size == torch.Size([2, 3])
+
+    def test_batch_meta_concat_with_list_extra_info(self):
+        """Example: Concat handles list extra_info by flattening."""
+        fields = {
+            "test_field": FieldMeta(
+                name="test_field", dtype=torch.float32, shape=(2,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+
+        batch1 = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=0, fields=fields)])
+        batch1.extra_info["list"] = [1, 2, 3]
+
+        batch2 = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=1, fields=fields)])
+        batch2.extra_info["list"] = [4, 5, 6]
+
+        result = BatchMeta.concat([batch1, batch2])
+
+        # Lists are flattened
+        assert result.extra_info["list"] == [1, 2, 3, 4, 5, 6]
+
+    def test_batch_meta_concat_with_mixed_types(self):
+        """Example: Concat handles mixed extra_info types correctly."""
+        fields = {
+            "test_field": FieldMeta(
+                name="test_field", dtype=torch.float32, shape=(2,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+
+        batch1 = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=0, fields=fields)])
+        batch1.extra_info["tensor"] = torch.randn(3, 4)
+        batch1.extra_info["list"] = [1, 2, 3]
+        batch1.extra_info["string"] = "hello"
+        batch1.extra_info["non_tensor"] = NonTensorStack(1, 2, 3)
+
+        batch2 = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=1, fields=fields)])
+        batch2.extra_info["tensor"] = torch.randn(3, 4)
+        batch2.extra_info["list"] = [4, 5]
+        batch2.extra_info["string"] = "world"
+        batch2.extra_info["non_tensor"] = NonTensorStack(4, 5, 6)
+
+        result = BatchMeta.concat([batch1, batch2])
+
+        # Each type is handled appropriately
+        assert result.extra_info["tensor"].shape == (6, 4)  # Concatenated
+        assert result.extra_info["list"] == [1, 2, 3, 4, 5]  # Flattened
+        assert result.extra_info["string"] == "world"  # Last value wins
+        assert isinstance(result.extra_info["non_tensor"], NonTensorStack)  # Stacked
+
+    def test_batch_meta_union(self):
+        """Example: Union two batches with matching global indexes."""
+        fields1 = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+        }
+        fields2 = {
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+            "field3": FieldMeta(name="field3", dtype=torch.bool, shape=(4,)),
+        }
+
+        batch1 = BatchMeta(
+            samples=[
+                SampleMeta(partition_id="partition_0", global_index=0, fields=fields1),
+                SampleMeta(partition_id="partition_0", global_index=1, fields=fields1),
+            ]
+        )
+        batch1.extra_info["info1"] = "value1"
+
+        batch2 = BatchMeta(
+            samples=[
+                SampleMeta(partition_id="partition_0", global_index=0, fields=fields2),
+                SampleMeta(partition_id="partition_0", global_index=1, fields=fields2),
+            ]
+        )
+        batch2.extra_info["info2"] = "value2"
+
+        result = batch1.union(batch2)
+
+        assert len(result) == 2
+        # All fields are present
+        for sample in result.samples:
+            assert "field1" in sample.fields
+            assert "field2" in sample.fields
+            assert "field3" in sample.fields
+        # Extra info is merged
+        assert result.extra_info["info1"] == "value1"
+        assert result.extra_info["info2"] == "value2"
+
+    def test_batch_meta_union_validation(self):
+        """Example: Union validation catches mismatched conditions."""
+        fields = {"test_field": FieldMeta(name="test_field", dtype=torch.float32, shape=(2,))}
+
+        batch1 = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=0, fields=fields)])
+
+        batch2 = BatchMeta(
+            samples=[
+                SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+                SampleMeta(partition_id="partition_0", global_index=1, fields=fields),  # Different size
+            ]
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            batch1.union(batch2, validate=True)
+        assert "Batch sizes do not match" in str(exc_info.value)
+
+    def test_batch_meta_reorder(self):
+        """Example: Reorder samples in a batch."""
+        fields = {
+            "test_field": FieldMeta(
+                name="test_field", dtype=torch.float32, shape=(2,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+        samples = [
+            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+            SampleMeta(partition_id="partition_0", global_index=1, fields=fields),
+            SampleMeta(partition_id="partition_0", global_index=2, fields=fields),
+        ]
+        batch = BatchMeta(samples=samples)
+
+        # Reorder to [2, 0, 1]
+        batch.reorder([2, 0, 1])
+
+        assert batch.global_indexes == [2, 0, 1]
+        # Batch indexes are updated
+        assert batch.samples[0].batch_index == 0
+        assert batch.samples[1].batch_index == 1
+        assert batch.samples[2].batch_index == 2
+
+    def test_batch_meta_add_fields(self):
+        """Example: Add fields from TensorDict to all samples."""
+        fields = {
+            "test_field": FieldMeta(
+                name="test_field", dtype=torch.float32, shape=(2,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+        samples = [
+            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+            SampleMeta(partition_id="partition_0", global_index=1, fields=fields),
+        ]
+        batch = BatchMeta(samples=samples)
+
+        # Create TensorDict with new fields
+        tensor_dict = TensorDict({"new_field1": torch.randn(2, 3), "new_field2": torch.randn(2, 5)}, batch_size=[2])
+
+        batch.add_fields(tensor_dict)
+
+        # Fields are added to all samples
+        for sample in batch.samples:
+            assert "new_field1" in sample.fields
+            assert "new_field2" in sample.fields
+            assert sample.is_ready is True
+
+    def test_batch_meta_extra_info_operations(self):
+        """Example: Extra info management operations."""
+        fields = {
+            "test_field": FieldMeta(
+                name="test_field", dtype=torch.float32, shape=(2,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+        batch = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=0, fields=fields)])
+
+        # Set and get
+        batch.set_extra_info("key1", "value1")
+        assert batch.get_extra_info("key1") == "value1"
+        assert batch.has_extra_info("key1") is True
+
+        # Update multiple
+        batch.update_extra_info({"key2": "value2", "key3": "value3"})
+        assert batch.has_extra_info("key2") is True
+
+        # Remove
+        removed = batch.remove_extra_info("key2")
+        assert removed == "value2"
+        assert batch.has_extra_info("key2") is False
+
+        # Get all
+        all_info = batch.get_all_extra_info()
+        assert "key1" in all_info
+        assert "key3" in all_info
+
+        # Clear
+        batch.clear_extra_info()
+        assert len(batch.extra_info) == 0
+
+
+class TestEdgeCases:
+    """Edge cases and important boundaries."""
+
+    def test_batch_meta_chunk_with_more_chunks_than_samples(self):
+        """Example: Chunking when chunks > samples produces empty chunks."""
+        fields = {
+            "test_field": FieldMeta(
+                name="test_field", dtype=torch.float32, shape=(2,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+        samples = [
+            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+            SampleMeta(partition_id="partition_0", global_index=1, fields=fields),
+        ]
+        batch = BatchMeta(samples=samples)
+
+        # 5 chunks for 2 samples
+        chunks = batch.chunk(5)
+
+        assert len(chunks) == 5
+        # First 2 chunks have samples
+        assert len(chunks[0]) == 1
+        assert len(chunks[1]) == 1
+        # Last 3 chunks are empty
+        assert len(chunks[2]) == 0
+        assert len(chunks[3]) == 0
+        assert len(chunks[4]) == 0
+
+    def test_batch_meta_concat_with_empty_batches(self):
+        """Example: Concat handles empty batches gracefully."""
+        fields = {
+            "test_field": FieldMeta(
+                name="test_field", dtype=torch.float32, shape=(2,), production_status=ProductionStatus.READY_FOR_CONSUME
+            )
+        }
+
+        batch1 = BatchMeta(samples=[])
+        batch2 = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=0, fields=fields)])
+        batch3 = BatchMeta(samples=[])
+
+        # Empty batches are filtered out
+        result = BatchMeta.concat([batch1, batch2, batch3])
+        assert len(result) == 1
+        assert result.global_indexes == [0]
+
+    def test_batch_meta_concat_validation_error(self):
+        """Example: Concat validation catches field name mismatches."""
+        fields1 = {"field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,))}
+        fields2 = {"field2": FieldMeta(name="field2", dtype=torch.float32, shape=(2,))}
+
+        batch1 = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=0, fields=fields1)])
+
+        batch2 = BatchMeta(samples=[SampleMeta(partition_id="partition_0", global_index=1, fields=fields2)])
+
+        with pytest.raises(ValueError) as exc_info:
+            BatchMeta.concat([batch1, batch2], validate=True)
+        assert "Field names do not match" in str(exc_info.value)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -111,6 +111,60 @@ class TestSampleMeta:
         assert "field2" in sample.fields
         assert sample.is_ready is True
 
+    def test_sample_meta_select_fields(self):
+        """Example: Select specific fields from a sample."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+            "field3": FieldMeta(name="field3", dtype=torch.bool, shape=(4,)),
+        }
+        sample = SampleMeta(partition_id="partition_0", global_index=0, fields=fields)
+
+        # Select only field1 and field3
+        selected_sample = sample.select_fields(["field1", "field3"])
+
+        assert "field1" in selected_sample.fields
+        assert "field3" in selected_sample.fields
+        assert "field2" not in selected_sample.fields
+        # Original sample is unchanged
+        assert len(sample.fields) == 3
+        # Selected sample has correct metadata
+        assert selected_sample.fields["field1"].dtype == torch.float32
+        assert selected_sample.fields["field1"].shape == (2,)
+        assert selected_sample.global_index == 0
+        assert selected_sample.partition_id == "partition_0"
+
+    def test_sample_meta_select_fields_with_nonexistent_fields(self):
+        """Example: Select fields ignores non-existent field names."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+        }
+        sample = SampleMeta(partition_id="partition_0", global_index=0, fields=fields)
+
+        # Try to select a field that doesn't exist
+        selected_sample = sample.select_fields(["field1", "nonexistent_field"])
+
+        # Only existing field is selected
+        assert "field1" in selected_sample.fields
+        assert "nonexistent_field" not in selected_sample.fields
+        assert "field2" not in selected_sample.fields
+
+    def test_sample_meta_select_fields_empty_list(self):
+        """Example: Select with empty field list returns sample with no fields."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+        }
+        sample = SampleMeta(partition_id="partition_0", global_index=0, fields=fields)
+
+        # Select with empty list
+        selected_sample = sample.select_fields([])
+
+        assert len(selected_sample.fields) == 0
+        assert selected_sample.global_index == 0
+        assert selected_sample.partition_id == "partition_0"
+
 
 class TestBatchMeta:
     """BatchMeta learning examples - Core Operations."""
@@ -354,6 +408,117 @@ class TestBatchMeta:
             assert "new_field1" in sample.fields
             assert "new_field2" in sample.fields
             assert sample.is_ready is True
+
+    def test_batch_meta_select_fields(self):
+        """Example: Select specific fields from all samples in a batch."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+            "field3": FieldMeta(name="field3", dtype=torch.bool, shape=(4,)),
+        }
+        samples = [
+            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+            SampleMeta(partition_id="partition_0", global_index=1, fields=fields),
+        ]
+        batch = BatchMeta(samples=samples, extra_info={"test_key": "test_value"})
+
+        # Select only field1 and field3
+        selected_batch = batch.select_fields(["field1", "field3"])
+
+        # Check all samples have correct fields
+        assert len(selected_batch) == 2
+        for sample in selected_batch.samples:
+            assert "field1" in sample.fields
+            assert "field3" in sample.fields
+            assert "field2" not in sample.fields
+        # Original batch is unchanged
+        assert len(batch.samples[0].fields) == 3
+        # Extra info is preserved
+        assert selected_batch.extra_info["test_key"] == "test_value"
+        # Global indexes are preserved
+        assert selected_batch.global_indexes == [0, 1]
+
+    def test_batch_meta_select_fields_with_nonexistent_fields(self):
+        """Example: Select fields ignores non-existent field names in batch."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+        }
+        samples = [
+            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+            SampleMeta(partition_id="partition_0", global_index=1, fields=fields),
+        ]
+        batch = BatchMeta(samples=samples)
+
+        # Try to select fields including non-existent ones
+        selected_batch = batch.select_fields(["field1", "nonexistent_field"])
+
+        # Only existing fields are selected
+        for sample in selected_batch.samples:
+            assert "field1" in sample.fields
+            assert "nonexistent_field" not in sample.fields
+            assert "field2" not in sample.fields
+
+    def test_batch_meta_select_fields_empty_list(self):
+        """Example: Select with empty field list returns batch with no fields."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+        }
+        samples = [
+            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+            SampleMeta(partition_id="partition_0", global_index=1, fields=fields),
+        ]
+        batch = BatchMeta(samples=samples)
+
+        # Select with empty list
+        selected_batch = batch.select_fields([])
+
+        assert len(selected_batch) == 2
+        for sample in selected_batch.samples:
+            assert len(sample.fields) == 0
+        # Global indexes are preserved
+        assert selected_batch.global_indexes == [0, 1]
+
+    def test_batch_meta_select_fields_single_sample(self):
+        """Example: Select fields works correctly for batch with single sample."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+        }
+        sample = SampleMeta(partition_id="partition_0", global_index=0, fields=fields)
+        batch = BatchMeta(samples=[sample])
+
+        # Select only field2
+        selected_batch = batch.select_fields(["field2"])
+
+        assert len(selected_batch) == 1
+        assert "field2" in selected_batch.samples[0].fields
+        assert "field1" not in selected_batch.samples[0].fields
+
+    def test_batch_meta_select_fields_preserves_field_metadata(self):
+        """Example: Selected fields preserve their original metadata."""
+        fields = {
+            "field1": FieldMeta(
+                name="field1", dtype=torch.float32, shape=(2, 3), production_status=ProductionStatus.READY_FOR_CONSUME
+            ),
+            "field2": FieldMeta(
+                name="field2", dtype=torch.int64, shape=(5,), production_status=ProductionStatus.NOT_PRODUCED
+            ),
+        }
+        samples = [
+            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+        ]
+        batch = BatchMeta(samples=samples)
+
+        # Select field1
+        selected_batch = batch.select_fields(["field1"])
+        selected_field = selected_batch.samples[0].fields["field1"]
+
+        assert selected_field.dtype == torch.float32
+        assert selected_field.shape == (2, 3)
+        assert selected_field.production_status == ProductionStatus.READY_FOR_CONSUME
+        assert selected_field.name == "field1"
 
     def test_batch_meta_extra_info_operations(self):
         """Example: Extra info management operations."""

--- a/tests/test_serial_utils_on_cpu.py
+++ b/tests/test_serial_utils_on_cpu.py
@@ -47,36 +47,7 @@ def test_tensor_serialization(dtype):
 def test_zmq_msg_serialization():
     from transfer_queue.utils.zmq_utils import ZMQMessage, ZMQRequestType
 
-    # jagged tensor
-    msg = ZMQMessage(
-        request_type=ZMQRequestType.PUT_DATA,
-        sender_id="test_sender",
-        receiver_id="test_receiver",
-        request_id="test_request",
-        timestamp="test_timestamp",
-        body={
-            "data": TensorDict(
-                {
-                    "nested_tensor": torch.nested.as_nested_tensor(
-                        [torch.randn(2, 3), torch.randn(2, 4)], layout=torch.jagged
-                    ),
-                    "numpy_array": torch.randn(2, 2).numpy(),
-                },
-                batch_size=2,
-            )
-        },
-    )
-    encoded_msg = msg.serialize()
-    decoded_msg = ZMQMessage.deserialize(encoded_msg)
-    assert decoded_msg.request_type == msg.request_type
-    assert torch.allclose(decoded_msg.body["data"]["numpy_array"], msg.body["data"]["numpy_array"])
-    for i in range(len(msg.body["data"]["nested_tensor"].unbind())):
-        assert torch.allclose(
-            decoded_msg.body["data"]["nested_tensor"][i],
-            msg.body["data"]["nested_tensor"][i],
-        )
-
-    # strided tensor
+    # construct complex msg body with nested tensor, jagged tensor, normal tensor, numpy array
     msg = ZMQMessage(
         request_type=ZMQRequestType.PUT_DATA,
         sender_id="test_sender",
@@ -89,6 +60,10 @@ def test_zmq_msg_serialization():
                     "nested_tensor": torch.nested.as_nested_tensor(
                         [torch.randn(4, 3), torch.randn(2, 4)], layout=torch.strided
                     ),
+                    "jagged_tensor": torch.nested.as_nested_tensor(
+                        [torch.randn(4, 5), torch.randn(4, 54)], layout=torch.jagged
+                    ),
+                    "normal_tensor": torch.randn(2, 10, 3),
                     "numpy_array": torch.randn(2, 2).numpy(),
                 },
                 batch_size=2,
@@ -99,8 +74,51 @@ def test_zmq_msg_serialization():
     decoded_msg = ZMQMessage.deserialize(encoded_msg)
     assert decoded_msg.request_type == msg.request_type
     assert torch.allclose(decoded_msg.body["data"]["numpy_array"], msg.body["data"]["numpy_array"])
+    assert torch.allclose(decoded_msg.body["data"]["normal_tensor"], msg.body["data"]["normal_tensor"])
+    assert msg.body["data"]["nested_tensor"].layout == decoded_msg.body["data"]["nested_tensor"].layout
+    assert msg.body["data"]["jagged_tensor"].layout == decoded_msg.body["data"]["jagged_tensor"].layout
     for i in range(len(msg.body["data"]["nested_tensor"].unbind())):
         assert torch.allclose(
             decoded_msg.body["data"]["nested_tensor"][i],
             msg.body["data"]["nested_tensor"][i],
         )
+    for i in range(len(msg.body["data"]["jagged_tensor"].unbind())):
+        assert torch.allclose(
+            decoded_msg.body["data"]["jagged_tensor"][i],
+            msg.body["data"]["jagged_tensor"][i],
+        )
+
+
+@pytest.mark.parametrize(
+    "make_view",
+    [
+        lambda x: x[:, :5],
+        lambda x: x[::2],
+        lambda x: x[..., 1:],
+        lambda x: x.transpose(0, 1),
+        lambda x: x[1:-1, 2:8:2],
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+    ],
+)
+def test_tensor_serialization_with_views(dtype, make_view):
+    encoder = MsgpackEncoder()
+    decoder = MsgpackDecoder(torch.Tensor)
+
+    base = torch.randn(16, 16, dtype=dtype)
+    view = make_view(base)
+
+    print("is_view_like:", view._base is not None, "is_contiguous:", view.is_contiguous())
+
+    serialized = encoder.encode(view)
+    deserialized = decoder.decode(serialized)
+
+    assert deserialized.shape == view.shape
+    assert deserialized.dtype == view.dtype
+    assert torch.allclose(view, deserialized)

--- a/tests/test_storage_client_factory.py
+++ b/tests/test_storage_client_factory.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The TransferQueue Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 from importlib.util import find_spec
 

--- a/transfer_queue/client.py
+++ b/transfer_queue/client.py
@@ -365,7 +365,8 @@ class AsyncTransferQueueClient:
                 "Call initialize_storage_manager() before performing storage operations."
             )
 
-        if not metadata or metadata.size == 0:
+        if not metadata or metadata.size == 0 or len(metadata._field_names) == 0:
+            logger.warning(f"[{self.client_id}]: Empty BatchMeta provided to get_data. Returning empty TensorDict.")
             return TensorDict({}, batch_size=0)
 
         results = await self.storage_manager.get_data(metadata)

--- a/transfer_queue/metadata.py
+++ b/transfer_queue/metadata.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("TQ_LOGGING_LEVEL", logging.WARNING))
 
 
+# TODO: Add UT for metadata operations
 @dataclass
 class FieldMeta:
     """Records the metadata of a single data field (name, dtype, shape, etc.)."""
@@ -261,6 +262,12 @@ class BatchMeta:
         chunk_list = []
         n = len(self.samples)
 
+        if n < chunks:
+            logger.warning(
+                f"Chunk size {chunks} > number of samples in BatchMeta {n}, this will return some "
+                f"empty BatchMeta chunks."
+            )
+
         # Calculate the base size and remainder of each chunk
         base_size = n // chunks
         remainder = n % chunks
@@ -277,7 +284,7 @@ class BatchMeta:
         return chunk_list
 
     @classmethod
-    def concat(cls, data: list["BatchMeta"], validate: bool = True) -> Optional["BatchMeta"]:
+    def concat(cls, data: list["BatchMeta"], validate: bool = True) -> "BatchMeta":
         """
         Concatenate multiple BatchMeta chunks into one large batch.
 
@@ -292,7 +299,15 @@ class BatchMeta:
             ValueError: If validation fails (e.g., field names do not match)
         """
         if not data:
-            return None
+            logger.warning("Try to concat empty BatchMeta chunks. Returning empty BatchMeta.")
+            return BatchMeta(samples=[], extra_info={})
+
+        # skip empty chunks
+        data = [chunk for chunk in data if chunk and len(chunk.samples) > 0]
+
+        if len(data) == 0:
+            logger.warning("No valid BatchMeta chunks to concatenate. Returning empty BatchMeta.")
+            return BatchMeta(samples=[], extra_info={})
 
         if validate:
             base_fields = data[0].field_names

--- a/transfer_queue/metadata.py
+++ b/transfer_queue/metadata.py
@@ -103,6 +103,23 @@ class SampleMeta:
         object.__setattr__(self, "_is_ready", all(field.is_ready for field in self.fields.values()))
         return self
 
+    def select_fields(self, field_names: list[str]) -> "SampleMeta":
+        """
+        Select specific fields from this sample.
+        This will construct a new SampleMeta instance containing only the specified fields.
+
+        Args:
+            field_names (list[str]): List of field names to retain.
+        """
+        selected_fields = {name: self.fields[name] for name in field_names if name in self.fields}
+
+        # construct new SampleMeta instance
+        selected_sample_meta = SampleMeta(
+            fields=selected_fields, partition_id=self.partition_id, global_index=self.global_index
+        )
+
+        return selected_sample_meta
+
     def union(self, other: "SampleMeta", validate: bool = True) -> "SampleMeta":
         """
         Create a union of this sample's fields with another sample's fields.
@@ -160,8 +177,11 @@ class BatchMeta:
 
             object.__setattr__(self, "_global_indexes", [sample.global_index for sample in self.samples])
 
-            # assume all samples have the same fields.
-            object.__setattr__(self, "_field_names", sorted(self.samples[0].field_names))
+            # check if all samples have the same field names
+            first_sample_field_names = sorted(self.samples[0].field_names)
+            if not all(sorted(sample.field_names) == first_sample_field_names for sample in self.samples):
+                raise ValueError("All samples in BatchMeta must have the same field_names.")
+            object.__setattr__(self, "_field_names", first_sample_field_names)
         else:
             object.__setattr__(self, "_global_indexes", [])
             object.__setattr__(self, "_field_names", [])
@@ -237,6 +257,22 @@ class BatchMeta:
             object.__setattr__(self, "_field_names", sorted(self.samples[0].field_names))
             object.__setattr__(self, "_is_ready", all(sample.is_ready for sample in self.samples))
         return self
+
+    def select_fields(self, field_names: list[str]) -> "BatchMeta":
+        """
+        Select specific fields from all samples in this batch.
+        This will construct a new BatchMeta instance containing only the specified fields.
+
+        Args:
+            field_names (list[str]): List of field names to retain.
+        """
+        # select fields for each SampleMeta
+        new_samples = [sample.select_fields(field_names=field_names) for sample in self.samples]
+
+        # construct new BatchMeta instance
+        new_batch_meta = BatchMeta(samples=new_samples, extra_info=self.extra_info)
+
+        return new_batch_meta
 
     def __len__(self) -> int:
         """Return the number of samples in this batch."""

--- a/transfer_queue/utils/serial_utils.py
+++ b/transfer_queue/utils/serial_utils.py
@@ -85,6 +85,8 @@ class MsgpackEncoder:
 
     def _encode_tensor(self, obj: torch.Tensor) -> tuple[str, list[tensorenc]] | tensorenc:
         assert self.aux_buffers is not None
+        assert obj.device.type == "cpu", f"MsgpackEncoder only supports CPU tensors, got {obj.device}"
+        assert not obj.is_sparse, "Sparse tensors are not supported yet for MsgpackEncoder."
         # view the tensor as a contiguous 1D array of bytes
         arr = obj.flatten().contiguous().view(torch.uint8).numpy()
         data = len(self.aux_buffers)

--- a/transfer_queue/utils/zmq_utils.py
+++ b/transfer_queue/utils/zmq_utils.py
@@ -135,6 +135,8 @@ class ZMQMessage:
             timestamp=time.time(),
         )
 
+    # TODO: split the zero copy optimization from zmq_utils.py to serial_utils.py.
+    #       We hope to provide a general serialization util for tensordict (both device-side and cpu-side)
     def serialize(
         self,
     ) -> list[bytestr]:


### PR DESCRIPTION
## Background

TransferQueue supports fine-grained data read/write in sub-sample level, i.e., we can access to single field of a sample, rather than retrieve/overwrite the whole sample.

To better support this feature, we provide two functions that can be used to select part of the fields of a given batch/sample.

## Usage
Refer to `test_metadata.py`

```python3
    def test_sample_meta_select_fields(self):
        """Example: Select specific fields from a sample."""
        fields = {
            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
            "field3": FieldMeta(name="field3", dtype=torch.bool, shape=(4,)),
        }
        sample = SampleMeta(partition_id="partition_0", global_index=0, fields=fields)

        # Select only field1 and field3
        selected_sample = sample.select_fields(["field1", "field3"])

        assert "field1" in selected_sample.fields
        assert "field3" in selected_sample.fields
        assert "field2" not in selected_sample.fields
        # Original sample is unchanged
        assert len(sample.fields) == 3
        # Selected sample has correct metadata
        assert selected_sample.fields["field1"].dtype == torch.float32
        assert selected_sample.fields["field1"].shape == (2,)
        assert selected_sample.global_index == 0
        assert selected_sample.partition_id == "partition_0"

    def test_batch_meta_select_fields_with_nonexistent_fields(self):
        """Example: Select fields ignores non-existent field names in batch."""
        fields = {
            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
        }
        samples = [
            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
            SampleMeta(partition_id="partition_0", global_index=1, fields=fields),
        ]
        batch = BatchMeta(samples=samples)

        # Try to select fields including non-existent ones
        selected_batch = batch.select_fields(["field1", "nonexistent_field"])

        # Only existing fields are selected
        for sample in selected_batch.samples:
            assert "field1" in sample.fields
            assert "nonexistent_field" not in sample.fields
            assert "field2" not in sample.fields


```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added field selection capabilities to metadata operations.

* **Bug Fixes**
  * Improved handling of empty batches during concatenation.
  * Enhanced validation for batch consistency across samples.
  * Added safeguards for tensor serialization constraints.

* **Tests**
  * Expanded test coverage for metadata and tensor serialization operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->