### PR TITLE
[Feat] Add select_fields for BatchMeta & SampleMeta

### DIFF
--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -111,6 +111,60 @@ class TestSampleMeta:
         assert "field2" in sample.fields
         assert sample.is_ready is True
 
+    def test_sample_meta_select_fields(self):
+        """Example: Select specific fields from a sample."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+            "field3": FieldMeta(name="field3", dtype=torch.bool, shape=(4,)),
+        }
+        sample = SampleMeta(partition_id="partition_0", global_index=0, fields=fields)
+
+        # Select only field1 and field3
+        selected_sample = sample.select_fields(["field1", "field3"])
+
+        assert "field1" in selected_sample.fields
+        assert "field3" in selected_sample.fields
+        assert "field2" not in selected_sample.fields
+        # Original sample is unchanged
+        assert len(sample.fields) == 3
+        # Selected sample has correct metadata
+        assert selected_sample.fields["field1"].dtype == torch.float32
+        assert selected_sample.fields["field1"].shape == (2,)
+        assert selected_sample.global_index == 0
+        assert selected_sample.partition_id == "partition_0"
+
+    def test_sample_meta_select_fields_with_nonexistent_fields(self):
+        """Example: Select fields ignores non-existent field names."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+        }
+        sample = SampleMeta(partition_id="partition_0", global_index=0, fields=fields)
+
+        # Try to select a field that doesn't exist
+        selected_sample = sample.select_fields(["field1", "nonexistent_field"])
+
+        # Only existing field is selected
+        assert "field1" in selected_sample.fields
+        assert "nonexistent_field" not in selected_sample.fields
+        assert "field2" not in selected_sample.fields
+
+    def test_sample_meta_select_fields_empty_list(self):
+        """Example: Select with empty field list returns sample with no fields."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+        }
+        sample = SampleMeta(partition_id="partition_0", global_index=0, fields=fields)
+
+        # Select with empty list
+        selected_sample = sample.select_fields([])
+
+        assert len(selected_sample.fields) == 0
+        assert selected_sample.global_index == 0
+        assert selected_sample.partition_id == "partition_0"
+
 
 class TestBatchMeta:
     """BatchMeta learning examples - Core Operations."""
@@ -354,6 +408,117 @@ class TestBatchMeta:
             assert "new_field1" in sample.fields
             assert "new_field2" in sample.fields
             assert sample.is_ready is True
+
+    def test_batch_meta_select_fields(self):
+        """Example: Select specific fields from all samples in a batch."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+            "field3": FieldMeta(name="field3", dtype=torch.bool, shape=(4,)),
+        }
+        samples = [
+            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+            SampleMeta(partition_id="partition_0", global_index=1, fields=fields),
+        ]
+        batch = BatchMeta(samples=samples, extra_info={"test_key": "test_value"})
+
+        # Select only field1 and field3
+        selected_batch = batch.select_fields(["field1", "field3"])
+
+        # Check all samples have correct fields
+        assert len(selected_batch) == 2
+        for sample in selected_batch.samples:
+            assert "field1" in sample.fields
+            assert "field3" in sample.fields
+            assert "field2" not in sample.fields
+        # Original batch is unchanged
+        assert len(batch.samples[0].fields) == 3
+        # Extra info is preserved
+        assert selected_batch.extra_info["test_key"] == "test_value"
+        # Global indexes are preserved
+        assert selected_batch.global_indexes == [0, 1]
+
+    def test_batch_meta_select_fields_with_nonexistent_fields(self):
+        """Example: Select fields ignores non-existent field names in batch."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+        }
+        samples = [
+            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+            SampleMeta(partition_id="partition_0", global_index=1, fields=fields),
+        ]
+        batch = BatchMeta(samples=samples)
+
+        # Try to select fields including non-existent ones
+        selected_batch = batch.select_fields(["field1", "nonexistent_field"])
+
+        # Only existing fields are selected
+        for sample in selected_batch.samples:
+            assert "field1" in sample.fields
+            assert "nonexistent_field" not in sample.fields
+            assert "field2" not in sample.fields
+
+    def test_batch_meta_select_fields_empty_list(self):
+        """Example: Select with empty field list returns batch with no fields."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+        }
+        samples = [
+            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+            SampleMeta(partition_id="partition_0", global_index=1, fields=fields),
+        ]
+        batch = BatchMeta(samples=samples)
+
+        # Select with empty list
+        selected_batch = batch.select_fields([])
+
+        assert len(selected_batch) == 2
+        for sample in selected_batch.samples:
+            assert len(sample.fields) == 0
+        # Global indexes are preserved
+        assert selected_batch.global_indexes == [0, 1]
+
+    def test_batch_meta_select_fields_single_sample(self):
+        """Example: Select fields works correctly for batch with single sample."""
+        fields = {
+            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
+            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
+        }
+        sample = SampleMeta(partition_id="partition_0", global_index=0, fields=fields)
+        batch = BatchMeta(samples=[sample])
+
+        # Select only field2
+        selected_batch = batch.select_fields(["field2"])
+
+        assert len(selected_batch) == 1
+        assert "field2" in selected_batch.samples[0].fields
+        assert "field1" not in selected_batch.samples[0].fields
+
+    def test_batch_meta_select_fields_preserves_field_metadata(self):
+        """Example: Selected fields preserve their original metadata."""
+        fields = {
+            "field1": FieldMeta(
+                name="field1", dtype=torch.float32, shape=(2, 3), production_status=ProductionStatus.READY_FOR_CONSUME
+            ),
+            "field2": FieldMeta(
+                name="field2", dtype=torch.int64, shape=(5,), production_status=ProductionStatus.NOT_PRODUCED
+            ),
+        }
+        samples = [
+            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
+        ]
+        batch = BatchMeta(samples=samples)
+
+        # Select field1
+        selected_batch = batch.select_fields(["field1"])
+        selected_field = selected_batch.samples[0].fields["field1"]
+
+        assert selected_field.dtype == torch.float32
+        assert selected_field.shape == (2, 3)
+        assert selected_field.production_status == ProductionStatus.READY_FOR_CONSUME
+        assert selected_field.name == "field1"
 
     def test_batch_meta_extra_info_operations(self):
         """Example: Extra info management operations."""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -187,6 +187,21 @@ class TestBatchMeta:
         assert len(chunks[1]) == 3
         assert len(chunks[2]) == 3
 
+    def test_batch_meta_init_validation_error_different_field_names(self):
+        """Example: Init validation catches samples with different field names."""
+        # Create first sample with field1
+        fields1 = {"field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,))}
+        sample1 = SampleMeta(partition_id="partition_0", global_index=0, fields=fields1)
+
+        # Create second sample with field2
+        fields2 = {"field2": FieldMeta(name="field2", dtype=torch.float32, shape=(2,))}
+        sample2 = SampleMeta(partition_id="partition_0", global_index=1, fields=fields2)
+
+        # Attempt to create BatchMeta with samples having different field names
+        with pytest.raises(ValueError) as exc_info:
+            BatchMeta(samples=[sample1, sample2])
+        assert "All samples in BatchMeta must have the same field_names." in str(exc_info.value)
+
     def test_batch_meta_concat(self):
         """Example: Concatenate multiple batches."""
         fields = {

--- a/transfer_queue/client.py
+++ b/transfer_queue/client.py
@@ -365,7 +365,8 @@ class AsyncTransferQueueClient:
                 "Call initialize_storage_manager() before performing storage operations."
             )
 
-        if not metadata or metadata.size == 0:
+        if not metadata or metadata.size == 0 or len(metadata._field_names) == 0:
+            logger.warning(f"[{self.client_id}]: Empty BatchMeta provided to get_data. Returning empty TensorDict.")
             return TensorDict({}, batch_size=0)
 
         results = await self.storage_manager.get_data(metadata)

--- a/transfer_queue/client.py
+++ b/transfer_queue/client.py
@@ -365,7 +365,7 @@ class AsyncTransferQueueClient:
                 "Call initialize_storage_manager() before performing storage operations."
             )
 
-        if not metadata or metadata.size == 0 or len(metadata._field_names) == 0:
+        if not metadata or metadata.size == 0 or len(metadata.field_names) == 0:
             logger.warning(f"[{self.client_id}]: Empty BatchMeta provided to get_data. Returning empty TensorDict.")
             return TensorDict({}, batch_size=0)
 

--- a/transfer_queue/metadata.py
+++ b/transfer_queue/metadata.py
@@ -110,6 +110,9 @@ class SampleMeta:
 
         Args:
             field_names (list[str]): List of field names to retain.
+
+        Returns:
+            SampleMeta: A new SampleMeta instance containing only the specified fields.
         """
         selected_fields = {name: self.fields[name] for name in field_names if name in self.fields}
 

--- a/transfer_queue/metadata.py
+++ b/transfer_queue/metadata.py
@@ -268,6 +268,9 @@ class BatchMeta:
 
         Args:
             field_names (list[str]): List of field names to retain.
+
+        Returns:
+            BatchMeta: A new BatchMeta instance containing only the specified fields from all samples.
         """
         # select fields for each SampleMeta
         new_samples = [sample.select_fields(field_names=field_names) for sample in self.samples]

--- a/transfer_queue/metadata.py
+++ b/transfer_queue/metadata.py
@@ -270,7 +270,7 @@ class BatchMeta:
         new_samples = [sample.select_fields(field_names=field_names) for sample in self.samples]
 
         # construct new BatchMeta instance
-        new_batch_meta = BatchMeta(samples=new_samples, extra_info=self.extra_info)
+        new_batch_meta = BatchMeta(samples=new_samples, extra_info=self.extra_info.copy())
 
         return new_batch_meta
 

--- a/transfer_queue/metadata.py
+++ b/transfer_queue/metadata.py
@@ -103,6 +103,23 @@ class SampleMeta:
         object.__setattr__(self, "_is_ready", all(field.is_ready for field in self.fields.values()))
         return self
 
+    def select_fields(self, field_names: list[str]) -> "SampleMeta":
+        """
+        Select specific fields from this sample.
+        This will construct a new SampleMeta instance containing only the specified fields.
+
+        Args:
+            field_names (list[str]): List of field names to retain.
+        """
+        selected_fields = {name: self.fields[name] for name in field_names if name in self.fields}
+
+        # construct new SampleMeta instance
+        selected_sample_meta = SampleMeta(
+            fields=selected_fields, partition_id=self.partition_id, global_index=self.global_index
+        )
+
+        return selected_sample_meta
+
     def union(self, other: "SampleMeta", validate: bool = True) -> "SampleMeta":
         """
         Create a union of this sample's fields with another sample's fields.
@@ -160,8 +177,11 @@ class BatchMeta:
 
             object.__setattr__(self, "_global_indexes", [sample.global_index for sample in self.samples])
 
-            # assume all samples have the same fields.
-            object.__setattr__(self, "_field_names", sorted(self.samples[0].field_names))
+            # check if all samples have the same field names
+            first_sample_field_names = sorted(self.samples[0].field_names)
+            if not all(sorted(sample.field_names) == first_sample_field_names for sample in self.samples):
+                raise ValueError("All samples in BatchMeta must have the same field_names.")
+            object.__setattr__(self, "_field_names", first_sample_field_names)
         else:
             object.__setattr__(self, "_global_indexes", [])
             object.__setattr__(self, "_field_names", [])
@@ -237,6 +257,22 @@ class BatchMeta:
             object.__setattr__(self, "_field_names", sorted(self.samples[0].field_names))
             object.__setattr__(self, "_is_ready", all(sample.is_ready for sample in self.samples))
         return self
+
+    def select_fields(self, field_names: list[str]) -> "BatchMeta":
+        """
+        Select specific fields from all samples in this batch.
+        This will construct a new BatchMeta instance containing only the specified fields.
+
+        Args:
+            field_names (list[str]): List of field names to retain.
+        """
+        # select fields for each SampleMeta
+        new_samples = [sample.select_fields(field_names=field_names) for sample in self.samples]
+
+        # construct new BatchMeta instance
+        new_batch_meta = BatchMeta(samples=new_samples, extra_info=self.extra_info)
+
+        return new_batch_meta
 
     def __len__(self) -> int:
         """Return the number of samples in this batch."""


### PR DESCRIPTION
## Background

TransferQueue supports fine-grained data read/write in sub-sample level, i.e., we can access to single field of a sample, rather than retrieve/overwrite the whole sample.

To better support this feature, we provide two functions that can be used to select part of the fields of a given batch/sample.

## Usage
Refer to `test_metadata.py`

```python3
    def test_sample_meta_select_fields(self):
        """Example: Select specific fields from a sample."""
        fields = {
            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
            "field3": FieldMeta(name="field3", dtype=torch.bool, shape=(4,)),
        }
        sample = SampleMeta(partition_id="partition_0", global_index=0, fields=fields)

        # Select only field1 and field3
        selected_sample = sample.select_fields(["field1", "field3"])

        assert "field1" in selected_sample.fields
        assert "field3" in selected_sample.fields
        assert "field2" not in selected_sample.fields
        # Original sample is unchanged
        assert len(sample.fields) == 3
        # Selected sample has correct metadata
        assert selected_sample.fields["field1"].dtype == torch.float32
        assert selected_sample.fields["field1"].shape == (2,)
        assert selected_sample.global_index == 0
        assert selected_sample.partition_id == "partition_0"

    def test_batch_meta_select_fields_with_nonexistent_fields(self):
        """Example: Select fields ignores non-existent field names in batch."""
        fields = {
            "field1": FieldMeta(name="field1", dtype=torch.float32, shape=(2,)),
            "field2": FieldMeta(name="field2", dtype=torch.int64, shape=(3,)),
        }
        samples = [
            SampleMeta(partition_id="partition_0", global_index=0, fields=fields),
            SampleMeta(partition_id="partition_0", global_index=1, fields=fields),
        ]
        batch = BatchMeta(samples=samples)

        # Try to select fields including non-existent ones
        selected_batch = batch.select_fields(["field1", "nonexistent_field"])

        # Only existing fields are selected
        for sample in selected_batch.samples:
            assert "field1" in sample.fields
            assert "nonexistent_field" not in sample.fields
            assert "field2" not in sample.fields


```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `select_fields()` method to extract specific fields from samples and batches

* **Bug Fixes**
  * Improved handling of empty field metadata during data retrieval
  * Added validation to ensure consistent field names across batch samples

* **Tests**
  * Extended test coverage for field selection functionality at sample and batch levels

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->