### PR TITLE
[Fix] Fix zero-copy serialization for single nested tensor

### DIFF
--- a/tests/test_serial_utils_on_cpu.py
+++ b/tests/test_serial_utils_on_cpu.py
@@ -541,3 +541,56 @@ def test_nested_jagged_tensor_serialization(enable_zero_copy):
         # Verify individual components
         for i in range(len(outer_td["nested_jagged1"].unbind())):
             assert torch.allclose(decoded_msg.body["data"]["nested_jagged1"][i], outer_td["nested_jagged1"][i])
+
+
+@pytest.mark.parametrize("enable_zero_copy", [True, False])
+def test_single_nested_tensor_serialization(enable_zero_copy):
+    """Test serialization of nested tensor with only one element (edge case for zero-copy)."""
+    with patch("transfer_queue.utils.zmq_utils.TQ_ZERO_COPY_SERIALIZATION", enable_zero_copy):
+        from transfer_queue.utils.zmq_utils import ZMQMessage, ZMQRequestType
+
+        # Create nested tensor with only one element
+        # This is the critical edge case where a nested tensor with 1 element
+        # must be distinguished from a regular tensor during deserialization
+        single_nested = torch.nested.as_nested_tensor([torch.randn(4, 3)], layout=torch.strided)
+        # For normal tensor, expand to batch_size=1 to match the nested tensor's batch dimension
+        normal_tensor = torch.randn(1, 4, 3)
+
+        # Create TensorDict with both types
+        td = TensorDict(
+            {
+                "single_nested_tensor": single_nested,
+                "normal_tensor": normal_tensor,
+            },
+            batch_size=1,
+        )
+
+        msg = ZMQMessage(
+            request_type=ZMQRequestType.PUT_DATA,
+            sender_id="test",
+            receiver_id="test",
+            request_id="test",
+            timestamp=0.0,
+            body={"data": td},
+        )
+
+        encoded_msg = msg.serialize()
+        decoded_msg = ZMQMessage.deserialize(encoded_msg)
+
+        # Verify batch sizes
+        assert decoded_msg.body["data"].batch_size == td.batch_size
+
+        # Verify normal tensor
+        assert torch.allclose(decoded_msg.body["data"]["normal_tensor"], td["normal_tensor"])
+        assert decoded_msg.body["data"]["normal_tensor"].shape == td["normal_tensor"].shape
+
+        # Verify single nested tensor is properly reconstructed as nested
+        assert decoded_msg.body["data"]["single_nested_tensor"].is_nested
+        assert decoded_msg.body["data"]["single_nested_tensor"].layout == torch.strided
+        assert len(decoded_msg.body["data"]["single_nested_tensor"].unbind()) == 1
+        assert torch.allclose(decoded_msg.body["data"]["single_nested_tensor"][0], td["single_nested_tensor"][0])
+
+        # Ensure the nested tensor with single element is correctly distinguished from regular tensor
+        # Both should have the same data but different types
+        assert not decoded_msg.body["data"]["normal_tensor"].is_nested
+        assert decoded_msg.body["data"]["single_nested_tensor"].is_nested

--- a/transfer_queue/storage/managers/simple_backend_manager.py
+++ b/transfer_queue/storage/managers/simple_backend_manager.py
@@ -230,7 +230,8 @@ class AsyncSimpleStorageManager(TransferQueueStorageManager):
                     else NonTensorStack(*transfer_data["field_data"][field])
                 )
                 for field in transfer_data["field_data"]
-            }
+            },
+            batch_size=len(local_indexes),
         )
 
         request_msg = ZMQMessage.create(

--- a/transfer_queue/utils/zmq_utils.py
+++ b/transfer_queue/utils/zmq_utils.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from typing import Any, Optional, TypeAlias
 from uuid import uuid4
 
+import numpy as np
 import psutil
 import torch
 import zmq
@@ -162,15 +163,15 @@ class ZMQMessage:
                     tensor_list = tensor.unbind()
                     tensor_count = len(tensor_list)
                     serialized_tensors = [_encoder.encode(inner_tensor) for inner_tensor in tensor_list]
-                    return tensor_count, serialized_tensors
+                    return tensor_count, serialized_tensors  # tensor_count may equal to 1 for single nested tensor
                 else:
-                    return 1, [_encoder.encode(tensor)]
+                    return -1, [_encoder.encode(tensor)]  # use -1 to indicate regular single tensor
 
             # Use map to process all tensors in parallel-like fashion
             nested_tensor_info_and_serialized_tensors = list(map(process_tensor, tensors))
 
             # Extract nested_tensor_info and flatten serialized tensors using itertools
-            nested_tensor_info = [info for info, _ in nested_tensor_info_and_serialized_tensors]
+            nested_tensor_info = np.array([info for info, _ in nested_tensor_info_and_serialized_tensors])
             double_layer_serialized_tensors: list[list[bytestr]] = list(
                 itertools.chain.from_iterable(serialized for _, serialized in nested_tensor_info_and_serialized_tensors)
             )
@@ -209,14 +210,14 @@ class ZMQMessage:
                     f"When TQ_ZERO_COPY_SERIALIZATION is enabled, input data should be a list, but got {type(data)}."
                 )
 
-            tensor_nums = sum(nested_tensor_info)
+            tensor_nums = np.abs(nested_tensor_info).sum()
             if tensor_nums != len(single_tensors):
                 raise ValueError(f"Expecting {tensor_nums} tensors, but got {len(single_tensors)}.")
 
             tensors = [None] * len(nested_tensor_info)
             current_idx = 0
             for i, tensor_num in enumerate(nested_tensor_info):
-                if tensor_num == 1:
+                if tensor_num == -1:
                     tensors[i] = single_tensors[current_idx]
                     current_idx += 1
                 else:


### PR DESCRIPTION
Fix bug introduced by #121 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization and deserialization of nested tensors to ensure proper reconstruction with correct layouts.
  * Enhanced batch size handling during data transfers for more accurate tensor operations.
  * Fixed distinction between nested and non-nested tensors in data serialization.

* **Tests**
  * Added test coverage for single-element nested tensor serialization scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->