### PR TITLE
[BREAKING][Fix] Fix controller concurrency error when expanding production/consumption status

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -91,7 +91,7 @@ class TestTransferQueueController:
             )
         )
         assert success
-        partition = ray.get(tq_controller.get_partition.remote(partition_id))
+        partition = ray.get(tq_controller.get_partition_snapshot.remote(partition_id))
         assert partition.production_status is not None
         assert partition.production_status.size(0) == gbs * num_n_samples
 
@@ -129,7 +129,7 @@ class TestTransferQueueController:
         assert gen_meta.global_indexes == list(range(gbs * num_n_samples))
         assert gen_meta.samples[0].partition_id == "train_0"
         assert gen_meta.field_names == ["prompt_ids"]
-        partition = ray.get(tq_controller.get_partition.remote(partition_id))
+        partition = ray.get(tq_controller.get_partition_snapshot.remote(partition_id))
         assert torch.equal(partition.consumption_status["generate_sequences"], torch.ones(gbs * num_n_samples))
         print("✓ Get metadata in fetch mode correct")
 
@@ -147,7 +147,7 @@ class TestTransferQueueController:
 
         # Test clear
         ray.get(tq_controller.clear.remote(partition_id))
-        partition = ray.get(tq_controller.get_partition.remote(partition_id))
+        partition = ray.get(tq_controller.get_partition_snapshot.remote(partition_id))
         partition_index_range = ray.get(tq_controller.get_partition_index_range.remote(partition_id))
         assert partition_index_range == set()
         assert torch.all(partition.production_status == 0)
@@ -258,14 +258,14 @@ class TestTransferQueueController:
         partition_index_range_1 = ray.get(tq_controller.get_partition_index_range.remote(partition_id_1))
         assert partition_index_range_1
         ray.get(tq_controller.clear.remote(partition_id_1))
-        partition_1_after_clear = ray.get(tq_controller.get_partition.remote(partition_id_1))
+        partition_1_after_clear = ray.get(tq_controller.get_partition_snapshot.remote(partition_id_1))
         partition_index_range_1_after_clear = ray.get(tq_controller.get_partition_index_range.remote(partition_id_1))
 
         assert not partition_index_range_1_after_clear
         assert torch.all(partition_1_after_clear.production_status[list(partition_index_range_1), :] == 0)
         assert torch.all(partition_1_after_clear.consumption_status["generate_sequences"] == 0)
 
-        partition_2 = ray.get(tq_controller.get_partition.remote(partition_id_2))
+        partition_2 = ray.get(tq_controller.get_partition_snapshot.remote(partition_id_2))
         partition_index_range_2 = ray.get(tq_controller.get_partition_index_range.remote(partition_id_2))
         # With per-partition indexing, partition2 uses indexes [0-15]
         assert partition_index_range_2 == set(range(part2_index_range))

--- a/tests/test_controller_data_partitions.py
+++ b/tests/test_controller_data_partitions.py
@@ -128,7 +128,7 @@ def test_partition_interface():
 
     # Test that the class can be imported and has expected methods
     assert hasattr(TransferQueueController, "create_partition")
-    assert hasattr(TransferQueueController, "get_partition")
+    assert hasattr(TransferQueueController, "get_partition_snapshot")
     assert hasattr(TransferQueueController, "update_production_status")
     assert hasattr(TransferQueueController, "scan_data_status")
     assert hasattr(TransferQueueController, "generate_batch_meta")

--- a/transfer_queue/controller.py
+++ b/transfer_queue/controller.py
@@ -689,7 +689,13 @@ class TransferQueueController:
         Returns:
             DataPartitionStatus object if partition exists, None otherwise
         """
-        return self.partitions.get(partition_id).to_snapshot()
+
+        partition = self._get_partition(partition_id)
+
+        if partition is None:
+            return None
+
+        return partition.to_snapshot()
 
     def list_partitions(self) -> list[str]:
         """

--- a/transfer_queue/controller.py
+++ b/transfer_queue/controller.py
@@ -18,7 +18,7 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass, field
 from operator import itemgetter
-from threading import Thread
+from threading import Lock, Thread
 from typing import Any, Optional
 from uuid import uuid4
 
@@ -212,6 +212,10 @@ class DataPartitionStatus:
     field_dtypes: dict[int, dict[str, Any]] = field(default_factory=dict)  # global_idx -> {field: dtype}
     field_shapes: dict[int, dict[str, Any]] = field(default_factory=dict)  # global_idx -> {field: shape}
 
+    # Threading lock for concurrency control; only for preventing mask operation error when expanding production_status.
+    # No need to strictly lock for every read/write operation since freshness is not critical.
+    data_status_lock: Lock = Lock()
+
     # Dynamic configuration - these are computed from the current state
     @property
     def total_samples_num(self) -> int:
@@ -323,7 +327,8 @@ class DataPartitionStatus:
             required_samples = max_sample_idx + 1
 
             # Ensure we have enough rows
-            self.ensure_samples_capacity(required_samples)
+            with self.data_status_lock:
+                self.ensure_samples_capacity(required_samples)
 
             # Register new fields if needed
             new_fields = [field for field in field_names if field not in self.field_name_mapping]
@@ -333,7 +338,8 @@ class DataPartitionStatus:
                     self.field_name_mapping[field] = len(self.field_name_mapping)
 
                 required_fields = len(self.field_name_mapping)
-                self.ensure_fields_capacity(required_fields)
+                with self.data_status_lock:
+                    self.ensure_fields_capacity(required_fields)
 
             # Update production status
             if self.production_status is not None and global_indices and field_names:
@@ -448,22 +454,23 @@ class DataPartitionStatus:
             if field_name not in self.field_name_mapping:
                 return []
 
-        row_mask = torch.ones(self.allocated_samples_num, dtype=torch.bool)
+        with self.data_status_lock:
+            row_mask = torch.ones(self.allocated_samples_num, dtype=torch.bool)
 
-        # Apply consumption filter (exclude already consumed samples)
-        consumption_status = self.get_consumption_status(task_name)
-        if consumption_status is not None:
-            unconsumed_mask = consumption_status == 0
-            row_mask &= unconsumed_mask
+            # Apply consumption filter (exclude already consumed samples)
+            consumption_status = self.get_consumption_status(task_name)
+            if consumption_status is not None:
+                unconsumed_mask = consumption_status == 0
+                row_mask &= unconsumed_mask
 
-        # Create column mask for requested fields
-        col_mask = torch.zeros(self.allocated_fields_num, dtype=torch.bool)
-        field_indices = [self.field_name_mapping[field] for field in field_names]
-        if field_indices:
-            col_mask[field_indices] = True
+            # Create column mask for requested fields
+            col_mask = torch.zeros(self.allocated_fields_num, dtype=torch.bool)
+            field_indices = [self.field_name_mapping[field] for field in field_names]
+            if field_indices:
+                col_mask[field_indices] = True
 
-        # Filter production status by masks
-        relevant_status = self.production_status[row_mask][:, col_mask]
+            # Filter production status by masks
+            relevant_status = self.production_status[row_mask][:, col_mask]
 
         # Check if all required fields are ready for each sample
         all_fields_ready = torch.all(relevant_status, dim=1)

--- a/transfer_queue/controller.py
+++ b/transfer_queue/controller.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import logging
 import os
 import time
@@ -535,6 +536,40 @@ class DataPartitionStatus:
 
         return stats
 
+    # ==================== Serialization ====================
+
+    def to_snapshot(self):
+        """
+        Get a snapshot of partition status information.
+
+        Returns:
+            DataPartitionStatus object without threading.Lock()
+        """
+
+        def _perform_copy():
+            cls = self.__class__
+            snapshot = cls.__new__(cls)
+
+            for name, value in self.__dict__.items():
+                if name == "data_status_lock":
+                    continue
+
+                if isinstance(value, torch.Tensor):
+                    new_val = value.clone().detach()
+                else:
+                    new_val = copy.deepcopy(value)
+
+                setattr(snapshot, name, new_val)
+            return snapshot
+
+        lock_obj = getattr(self, "data_status_lock", None)
+
+        if lock_obj:
+            with lock_obj:
+                return _perform_copy()
+        else:
+            return _perform_copy()
+
     def clear_data(self, global_indexes_range: list[int], clear_consumption: bool = True) -> bool:
         """Clear all production and optionally consumption data."""
         try:
@@ -632,7 +667,7 @@ class TransferQueueController:
         logger.info(f"Created partition {partition_id}")
         return True
 
-    def get_partition(self, partition_id: str) -> Optional[DataPartitionStatus]:
+    def _get_partition(self, partition_id: str) -> Optional[DataPartitionStatus]:
         """
         Get partition status information.
 
@@ -643,6 +678,18 @@ class TransferQueueController:
             DataPartitionStatus object if partition exists, None otherwise
         """
         return self.partitions.get(partition_id)
+
+    def get_partition_snapshot(self, partition_id: str) -> Optional[DataPartitionStatus]:
+        """
+        Get a copy of partition status information, without threading.Lock().
+
+        Args:
+            partition_id: ID of the partition to retrieve
+
+        Returns:
+            DataPartitionStatus object if partition exists, None otherwise
+        """
+        return self.partitions.get(partition_id).to_snapshot()
 
     def list_partitions(self) -> list[str]:
         """
@@ -708,7 +755,7 @@ class TransferQueueController:
         Returns:
             True if update was successful, False otherwise
         """
-        partition = self.get_partition(partition_id)
+        partition = self._get_partition(partition_id)
         if not partition:
             logger.error(f"Partition {partition_id} not found")
             return False
@@ -735,7 +782,7 @@ class TransferQueueController:
         Returns:
             Consumption status tensor if partition exists, None otherwise
         """
-        partition = self.get_partition(partition_id)
+        partition = self._get_partition(partition_id)
         if not partition:
             return None
 
@@ -884,7 +931,7 @@ class TransferQueueController:
         start_time = time.time()
 
         while True:
-            partition = self.get_partition(partition_id)
+            partition = self._get_partition(partition_id)
             if not partition:
                 if time.time() - start_time > timeout:
                     raise TimeoutError(f"Partition {partition_id} not found")
@@ -938,7 +985,7 @@ class TransferQueueController:
         Raises:
             ValueError: If partition doesn't exist or invalid mode
         """
-        partition = self.get_partition(partition_id)
+        partition = self._get_partition(partition_id)
         if not partition:
             raise ValueError(f"Partition {partition_id} not found")
 
@@ -1001,7 +1048,7 @@ class TransferQueueController:
         Returns:
             True if cleared successfully, False otherwise
         """
-        partition = self.get_partition(partition_id)
+        partition = self._get_partition(partition_id)
         if not partition:
             raise ValueError(f"Partition {partition_id} not found")
 

--- a/transfer_queue/controller.py
+++ b/transfer_queue/controller.py
@@ -214,7 +214,7 @@ class DataPartitionStatus:
 
     # Threading lock for concurrency control; only for preventing mask operation error when expanding production_status.
     # No need to strictly lock for every read/write operation since freshness is not critical.
-    data_status_lock: Lock = Lock()
+    data_status_lock: Lock = field(default_factory=Lock)
 
     # Dynamic configuration - these are computed from the current state
     @property


### PR DESCRIPTION
## Background

The `TransferQueueController` uses two separate threads to handle metadata retrieval (`_process_request`) and production status updates (`_update_data_status`). This design is intended to enable real-time production status updates and prevent potential blocking of metadata retrieval (consumption) requests (since we do this in a zmq request loop).

```python3
    def _start_process_update_data_status(self):
        """Start the data status update processing thread."""
        self.process_update_data_status_thread = Thread(
            target=self._update_data_status,
            name="TransferQueueControllerProcessUpdateDataStatusThread",
            daemon=True,
        )
        self.process_update_data_status_thread.start()

    def _start_process_request(self):
        """Start the request processing thread."""
        self.process_request_thread = Thread(
            target=self._process_request, name="TransferQueueControllerProcessRequestThread", daemon=True
        )
        self.process_request_thread.start()
```

However, when combined with the dynamic expansion capability introduced in #98, the mask operation on production_status fails under concurrent execution:

```python3
        row_mask = torch.ones(self.total_samples_num, dtype=torch.bool)

        # Apply consumption filter (exclude already consumed samples)
        consumption_status = self.get_consumption_status(task_name)
        if consumption_status is not None:
            unconsumed_mask = consumption_status == 0
            row_mask &= unconsumed_mask

        # Create column mask for requested fields
        col_mask = torch.zeros(self.allocated_fields_num, dtype=torch.bool)
        field_indices = [self.field_name_mapping[field] for field in field_names]
        if field_indices:
            col_mask[field_indices] = True

        # !!! This will fail when produciton status expands
        relevant_status = self.production_status[row_mask][:, col_mask]      

        # Check if all required fields are ready for each sample
        all_fields_ready = torch.all(relevant_status, dim=1)
        ready_indices_in_filtered = torch.nonzero(all_fields_ready, as_tuple=False).flatten()

```

Concurrent execution of:
1. The status update thread (modifying production_status dimensions via dynamic expansion)
2. The metadata retrieval thread (performing mask indexing on production_status)

leads to dimension mismatch errors during the row_mask/col_mask indexing step.

## Solution

To resolve this race condition:

- Introduce a threading.Lock() for each individual DataPartitionStatus instance
- Acquire the lock when accessing/modifying consumption_status or production_status during:
    - Mask operation (indexing)
    - Dynamic dimension expansion


Since we do not need to strictly make sure the consumption request getting the newest status, we do not need to acquire the lock for the entire read/write operation, leading to better performance.

NOTE: Since we add a threading.Lock(), the original `get_partition` will fail when trying to get the `DataPartitionStatus` out. Therefore, we make the original method to be a inner function, and provide another `get_partition_snapshot` for users who needs to retrieve the consumption status for debug.

```python3
    # in class DataPartitionStatus
    def to_snapshot(self):
        """
        Get a snapshot of partition status information.

        Returns:
            DataPartitionStatus object without threading.Lock()
        """

        def _perform_copy():
            cls = self.__class__
            snapshot = cls.__new__(cls)

            for name, value in self.__dict__.items():
                if name == "data_status_lock":
                    continue

                if isinstance(value, torch.Tensor):
                    new_val = value.clone().detach()
                else:
                    new_val = copy.deepcopy(value)

                setattr(snapshot, name, new_val)
            return snapshot

        lock_obj = getattr(self, "data_status_lock", None)

        if lock_obj:
            with lock_obj:
                return _perform_copy()
        else:
            return _perform_copy()

```

```python3
    # in class TransferQueueController
    def _get_partition(self, partition_id: str) -> Optional[DataPartitionStatus]:
        """
        Get partition status information.

        Args:
            partition_id: ID of the partition to retrieve

        Returns:
            DataPartitionStatus object if partition exists, None otherwise
        """
        return self.partitions.get(partition_id)

    def get_partition_snapshot(self, partition_id: str) -> Optional[DataPartitionStatus]:
        """
        Get a copy of partition status information, without threading.Lock().

        Args:
            partition_id: ID of the partition to retrieve

        Returns:
            DataPartitionStatus object if partition exists, None otherwise
        """
        return self.partitions.get(partition_id).to_snapshot()
```


Thanks @NINGBENZHE for pointing out this issue!

CC: @LLLLxmmm 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved synchronization mechanisms for data operations under concurrent access scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->