### PR TITLE
[Improvement] Modify controller global index allocation logic 

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -283,8 +283,9 @@ class TestTransferQueueController:
                 mode="insert",
             )
         )
-        # With per-partition indexing, partition3 reuses released indexes from partition1 [0-31]
-        # and then allocates new ones [32-63] for the remaining samples
+
+        # With per-partition indexing, partition3 uses its own independent index space [0-63]
+        # separate from partition1, without reusing indexes across partitions
         part3_index_range = gbs_3 * num_n_samples_3
         assert metadata_2.global_indexes == list(range(part3_index_range))
         assert metadata_2.samples[0].partition_id == "train_1"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -227,9 +227,9 @@ class TestTransferQueueController:
             )
         )
 
-        part1_index_range = gbs_1 * num_n_samples_1
+        # With per-partition independent indexing, partition2 starts from 0
         part2_index_range = gbs_2 * num_n_samples_2
-        assert val_metadata.global_indexes == list(range(part1_index_range, part2_index_range + part1_index_range))
+        assert val_metadata.global_indexes == list(range(part2_index_range))
         assert val_metadata.samples[0].partition_id == "val_0"
         assert sum([int(sample.fields.get("prompt_ids").production_status) for sample in val_metadata.samples]) == int(
             ProductionStatus.NOT_PRODUCED
@@ -238,7 +238,7 @@ class TestTransferQueueController:
             [int(sample.fields.get("attention_mask").production_status) for sample in val_metadata.samples]
         ) == int(ProductionStatus.NOT_PRODUCED)
         partition_index_range = ray.get(tq_controller.get_partition_index_range.remote(partition_id_2))
-        assert partition_index_range == set(range(part1_index_range, part2_index_range + part1_index_range))
+        assert partition_index_range == set(range(part2_index_range))
 
         # Update production status
         dtypes = {k: {"prompt_ids": "torch.int64", "attention_mask": "torch.bool"} for k in val_metadata.global_indexes}
@@ -267,7 +267,8 @@ class TestTransferQueueController:
 
         partition_2 = ray.get(tq_controller.get_partition.remote(partition_id_2))
         partition_index_range_2 = ray.get(tq_controller.get_partition_index_range.remote(partition_id_2))
-        assert partition_index_range_2 == set([32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47])
+        # With per-partition indexing, partition2 uses indexes [0-15]
+        assert partition_index_range_2 == set(range(part2_index_range))
         assert torch.all(
             partition_2.production_status[list(partition_index_range_2), : len(val_metadata.field_names)] == 1
         )
@@ -282,7 +283,10 @@ class TestTransferQueueController:
                 mode="insert",
             )
         )
-        assert metadata_2.global_indexes == list(range(32)) + list(range(48, 80))
+        # With per-partition indexing, partition3 reuses released indexes from partition1 [0-31]
+        # and then allocates new ones [32-63] for the remaining samples
+        part3_index_range = gbs_3 * num_n_samples_3
+        assert metadata_2.global_indexes == list(range(part3_index_range))
         assert metadata_2.samples[0].partition_id == "train_1"
         assert sum([int(sample.fields.get("prompt_ids").production_status) for sample in metadata_2.samples]) == int(
             ProductionStatus.NOT_PRODUCED
@@ -291,5 +295,5 @@ class TestTransferQueueController:
             [int(sample.fields.get("attention_mask").production_status) for sample in metadata_2.samples]
         ) == int(ProductionStatus.NOT_PRODUCED)
         partition_index_range = ray.get(tq_controller.get_partition_index_range.remote(partition_id_3))
-        assert partition_index_range == set(list(range(32)) + list(range(48, 80)))
+        assert partition_index_range == set(range(part3_index_range))
         print("✓ Correctly assign partition_3")

--- a/transfer_queue/controller.py
+++ b/transfer_queue/controller.py
@@ -75,24 +75,28 @@ class PartitionIndexManager:
     """
     Manages the mapping relationship between partitions and global indexes,
     responsible for index allocation and reuse.
+
+    Each partition has its own independent index space starting from 0,
+    allowing for more efficient memory usage and avoiding excessive allocation.
     """
 
     def __init__(self):
         # Records the set of global_indexes used by each partition
         self.partition_to_indexes = defaultdict(set)
 
-        # Reusable global_index pool - stored using list
-        self.reusable_indexes = []
+        # Per-partition reusable index pools - partition_id -> list of reusable indexes
+        self.partition_reusable_indexes = defaultdict(list)
 
-        # Global index counter for allocating new indexes
-        self.global_index_counter = 0
+        # Per-partition index counters for allocating new indexes
+        self.partition_counters = defaultdict(int)
 
-        # Track all active indexes
-        self.allocated_indexes = set()
+        # Track all active indexes per partition
+        self.partition_allocated_indexes = defaultdict(set)
 
     def allocate_indexes(self, partition_id, count=1) -> list:
         """
         Allocate global_indexes for the specified partition.
+        Each partition has its own independent index space starting from 0.
         Prioritizes obtaining from reusable pool, allocates new indexes when insufficient.
 
         Args:
@@ -106,29 +110,32 @@ class PartitionIndexManager:
             raise ValueError(f"Number of indexes needed must larger than 0, but got {count}")
         indexes = []
 
+        # Get partition-specific reusable pool
+        reusable_pool = self.partition_reusable_indexes[partition_id]
+
         # Get indexes from reusable pool
-        if self.reusable_indexes:
+        if reusable_pool:
             # Calculate number of indexes needed from reusable pool
-            num_reuse = min(count, len(self.reusable_indexes))
+            num_reuse = min(count, len(reusable_pool))
 
             # Use slice operation to get multiple elements at once (FIFO principle)
-            indexes.extend(self.reusable_indexes[:num_reuse])
-            del self.reusable_indexes[:num_reuse]
+            indexes.extend(reusable_pool[:num_reuse])
+            del reusable_pool[:num_reuse]
 
         # If reusable pool doesn't have enough indexes, allocate new ones
         if len(indexes) < count:
-            # Ensure newly allocated indexes don't conflict with existing ones
+            # Ensure newly allocated indexes don't conflict with existing ones in this partition
             needed = count - len(indexes)
-            # Batch allocate consecutive index ranges
-            start_index = self.global_index_counter
+            # Batch allocate consecutive index ranges starting from 0 for this partition
+            start_index = self.partition_counters[partition_id]
             end_index = start_index + needed
 
             # Directly generate consecutive index list
             new_indexes = list(range(start_index, end_index))
 
             # Batch update status
-            self.allocated_indexes.update(new_indexes)
-            self.global_index_counter = end_index
+            self.partition_allocated_indexes[partition_id].update(new_indexes)
+            self.partition_counters[partition_id] = end_index
 
             indexes.extend(new_indexes)
 
@@ -137,7 +144,7 @@ class PartitionIndexManager:
 
         return indexes
 
-    def release_indexes(self, partition_id):
+    def release_indexes(self, partition_id) -> list[int]:
         """
         Release all global_indexes of the specified partition, adding them to reusable pool.
 
@@ -150,17 +157,16 @@ class PartitionIndexManager:
         if partition_id in self.partition_to_indexes:
             indexes = self.partition_to_indexes.pop(partition_id)
 
-            # Add released indexes to reusable pool
-            self.reusable_indexes.extend(indexes)
+            # Add released indexes to partition-specific reusable pool
+            self.partition_reusable_indexes[partition_id].extend(indexes)
 
-            # Remove these indexes from allocated_indexes
-            for idx in indexes:
-                self.allocated_indexes.discard(idx)
+            # Remove these indexes from partition's allocated_indexes
+            self.partition_allocated_indexes[partition_id].difference_update(indexes)
 
             return indexes
         return []
 
-    def get_indexes_for_partition(self, partition_id):
+    def get_indexes_for_partition(self, partition_id) -> set[int]:
         """
         Get all global_indexes for the specified partition.
 

--- a/transfer_queue/controller.py
+++ b/transfer_queue/controller.py
@@ -93,7 +93,7 @@ class PartitionIndexManager:
         # Track all active indexes per partition
         self.partition_allocated_indexes = defaultdict(set)
 
-    def allocate_indexes(self, partition_id, count=1) -> list:
+    def allocate_indexes(self, partition_id, count=1) -> list[int]:
         """
         Allocate global_indexes for the specified partition.
         Each partition has its own independent index space starting from 0.
@@ -107,7 +107,7 @@ class PartitionIndexManager:
             list: List of allocated global_indexes
         """
         if count <= 0:
-            raise ValueError(f"Number of indexes needed must larger than 0, but got {count}")
+            raise ValueError(f"Number of indexes needed must be larger than 0, but got {count}")
         indexes = []
 
         # Get partition-specific reusable pool


### PR DESCRIPTION
**This PR is reverted since it introduces some bug.** #154 

## Background

As described in #146 , all the partitions share the same `production_status`, with different global_indexes allocated to different partitions to prevent error.

This will lead to performance issue since all the states are mixed together within a single tensor. Now we refactor the `PartitionIndexManager` so that each partition allocates their own global_indexes.


CC @LLLLxmmm 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal index management system to ensure each partition maintains independent index pools, enhancing efficiency in partitioned data operations.

* **Tests**
  * Updated test cases to align with the per-partition indexing behavior and verify correct index allocation and release across partitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->