### PR TITLE
[Fix] Controller trunks ready_samples that affects samplers

### DIFF
--- a/transfer_queue/controller.py
+++ b/transfer_queue/controller.py
@@ -883,6 +883,7 @@ class TransferQueueController:
 
             if len(ready_sample_indices) < batch_size:
                 if time.time() - start_time > timeout:
+                    # TODO: dont't raise error here, return empty list and let caller handle it (retry or not)
                     raise TimeoutError(
                         f"Timeout waiting for sufficient data in partition {partition_id}. "
                         f"Required: {batch_size}, Available: {len(ready_sample_indices)}"

--- a/transfer_queue/controller.py
+++ b/transfer_queue/controller.py
@@ -881,21 +881,21 @@ class TransferQueueController:
             # Use partition's own scanning method
             ready_sample_indices = partition.scan_data_status(data_fields, task_name)
 
-            if len(ready_sample_indices) >= batch_size:
-                return ready_sample_indices[:batch_size]
+            if len(ready_sample_indices) < batch_size:
+                if time.time() - start_time > timeout:
+                    raise TimeoutError(
+                        f"Timeout waiting for sufficient data in partition {partition_id}. "
+                        f"Required: {batch_size}, Available: {len(ready_sample_indices)}"
+                    )
 
-            if time.time() - start_time > timeout:
-                raise TimeoutError(
-                    f"Timeout waiting for sufficient data in partition {partition_id}. "
-                    f"Required: {batch_size}, Available: {len(ready_sample_indices)}"
+                logger.warning(
+                    f"Insufficient data in partition {partition_id} for task {task_name}: requiring {batch_size} "
+                    f"samples with {data_fields}, but only have {len(ready_sample_indices)} samples. "
+                    f"Retrying in {TQ_CONTROLLER_GET_METADATA_CHECK_INTERVAL}s..."
                 )
-
-            logger.warning(
-                f"Insufficient data in partition {partition_id} for task {task_name}: requiring {batch_size} samples "
-                f"with {data_fields}, but only have {len(ready_sample_indices)} samples. "
-                f"Retrying in {TQ_CONTROLLER_GET_METADATA_CHECK_INTERVAL}s..."
-            )
-            time.sleep(TQ_CONTROLLER_GET_METADATA_CHECK_INTERVAL)
+                time.sleep(TQ_CONTROLLER_GET_METADATA_CHECK_INTERVAL)
+            else:
+                return ready_sample_indices
 
     # ==================== Metadata Generation API ====================
 


### PR DESCRIPTION
## Background

Previous implementation of `scan_data_status` will trunk the ready_indexes according to given batch_size. This will block self-defined `Sampler` class from deciding which samples should be sampled.

```python3
            if len(ready_sample_indices) >= batch_size:
                return ready_sample_indices[:batch_size]
```

CC @LLLLxmmm 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated batch processing logic to ensure full batch size is available before processing. The system now waits for sufficient ready samples and logs status messages instead of processing partial batches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->