### PR TITLE
[BREAKING][Perf] Optimize TransferQueue memory usage

### DIFF
--- a/tests/test_simple_storage_unit.py
+++ b/tests/test_simple_storage_unit.py
@@ -21,7 +21,6 @@ import ray
 import tensordict
 import torch
 import zmq
-from tensordict import TensorDict
 
 # Setup path
 parent_dir = Path(__file__).resolve().parent.parent
@@ -108,13 +107,10 @@ def test_put_get_single_client(storage_setup):
 
     # PUT data
     local_indexes = [0, 1, 2]
-    field_data = TensorDict(
-        {
-            "log_probs": [torch.tensor([1.0, 2.0, 3.0]), torch.tensor([4.0, 5.0, 6.0]), torch.tensor([7.0, 8.0, 9.0])],
-            "rewards": [torch.tensor([10.0]), torch.tensor([20.0]), torch.tensor([30.0])],
-        },
-        batch_size=[],
-    )
+    field_data = {
+        "log_probs": [torch.tensor([1.0, 2.0, 3.0]), torch.tensor([4.0, 5.0, 6.0]), torch.tensor([7.0, 8.0, 9.0])],
+        "rewards": [torch.tensor([10.0]), torch.tensor([20.0]), torch.tensor([30.0])],
+    }
 
     response = client.send_put(0, local_indexes, field_data)
     assert response.request_type == ZMQRequestType.PUT_DATA_RESPONSE
@@ -126,8 +122,8 @@ def test_put_get_single_client(storage_setup):
     retrieved_data = response.body["data"]
     assert "log_probs" in retrieved_data
     assert "rewards" in retrieved_data
-    assert retrieved_data["log_probs"].size(0) == 2
-    assert retrieved_data["rewards"].size(0) == 2
+    assert len(retrieved_data["log_probs"]) == 2
+    assert len(retrieved_data["rewards"]) == 2
 
     # Verify data correctness
     torch.testing.assert_close(retrieved_data["log_probs"][0], torch.tensor([1.0, 2.0, 3.0]))
@@ -148,16 +144,14 @@ def test_put_get_multiple_clients(storage_setup):
     # Each client puts unique data using different local_indexes
     for i, client in enumerate(clients):
         local_indexes = [i * 10 + 0, i * 10 + 1, i * 10 + 2]
-        field_data = TensorDict(
-            {
-                "log_probs": [
-                    torch.tensor([i, i + 1, i + 2]),
-                    torch.tensor([i + 3, i + 4, i + 5]),
-                    torch.tensor([i + 6, i + 7, i + 8]),
-                ],
-                "rewards": [torch.tensor([i * 10]), torch.tensor([i * 10 + 10]), torch.tensor([i * 10 + 20])],
-            }
-        )
+        field_data = {
+            "log_probs": [
+                torch.tensor([i, i + 1, i + 2]),
+                torch.tensor([i + 3, i + 4, i + 5]),
+                torch.tensor([i + 6, i + 7, i + 8]),
+            ],
+            "rewards": [torch.tensor([i * 10]), torch.tensor([i * 10 + 10]), torch.tensor([i * 10 + 20])],
+        }
 
         response = client.send_put(i, local_indexes, field_data)
         assert response.request_type == ZMQRequestType.PUT_DATA_RESPONSE
@@ -165,7 +159,7 @@ def test_put_get_multiple_clients(storage_setup):
     # Test overlapping local indexes
     overlapping_client = MockStorageClient(put_get_address)
     overlap_local_indexes = [0]  # Overlaps with first client's index 0
-    overlap_field_data = TensorDict({"log_probs": [torch.tensor([999, 999, 999])], "rewards": [torch.tensor([999])]})
+    overlap_field_data = {"log_probs": [torch.tensor([999, 999, 999])], "rewards": [torch.tensor([999])]}
     response = overlapping_client.send_put(99, overlap_local_indexes, overlap_field_data)
     assert response.request_type == ZMQRequestType.PUT_DATA_RESPONSE
 
@@ -175,8 +169,8 @@ def test_put_get_multiple_clients(storage_setup):
         assert response.request_type == ZMQRequestType.GET_DATA_RESPONSE
 
         retrieved_data = response.body["data"]
-        assert retrieved_data["log_probs"].size(0) == 2
-        assert retrieved_data["rewards"].size(0) == 2
+        assert len(retrieved_data["log_probs"]) == 2
+        assert len(retrieved_data["rewards"]) == 2
 
         # For index 0, expect data from overlapping_client; others from original client
         if i == 0:
@@ -227,7 +221,7 @@ def test_performance_basic(storage_setup):
             log_probs_data.append(log_probs_tensor)
             rewards_data.append(rewards_tensor)
 
-        field_data = TensorDict({"log_probs": log_probs_data, "rewards": rewards_data}, batch_size=[batch_size])
+        field_data = {"log_probs": log_probs_data, "rewards": rewards_data}
 
         response = client.send_put(0, local_indexes, field_data)
         latency = time.time() - start
@@ -265,17 +259,14 @@ def test_put_get_nested_tensor(storage_setup):
 
     # PUT data with nested tensors
     local_indexes = [0, 1, 2]
-    field_data = TensorDict(
-        {
-            "variable_length_sequences": [
-                torch.tensor([-0.5, -1.2, -0.8]),
-                torch.tensor([-0.3, -1.5, -2.1, -0.9]),
-                torch.tensor([-1.1, -0.7]),
-            ],
-            "attention_mask": [torch.tensor([1, 1, 1]), torch.tensor([1, 1, 1, 1]), torch.tensor([1, 1])],
-        },
-        batch_size=[],
-    )
+    field_data = {
+        "variable_length_sequences": [
+            torch.tensor([-0.5, -1.2, -0.8]),
+            torch.tensor([-0.3, -1.5, -2.1, -0.9]),
+            torch.tensor([-1.1, -0.7]),
+        ],
+        "attention_mask": [torch.tensor([1, 1, 1]), torch.tensor([1, 1, 1, 1]), torch.tensor([1, 1])],
+    }
 
     response = client.send_put(0, local_indexes, field_data)
     assert response.request_type == ZMQRequestType.PUT_DATA_RESPONSE
@@ -287,8 +278,8 @@ def test_put_get_nested_tensor(storage_setup):
     retrieved_data = response.body["data"]
     assert "variable_length_sequences" in retrieved_data
     assert "attention_mask" in retrieved_data
-    assert retrieved_data["variable_length_sequences"].size(0) == 2
-    assert retrieved_data["attention_mask"].size(0) == 2
+    assert len(retrieved_data["variable_length_sequences"]) == 2
+    assert len(retrieved_data["attention_mask"]) == 2
 
     # Verify data correctness
     torch.testing.assert_close(retrieved_data["variable_length_sequences"][0], torch.tensor([-0.5, -1.2, -0.8]))
@@ -307,13 +298,10 @@ def test_put_get_non_tensor_data(storage_setup):
 
     # PUT data with non-tensor data
     local_indexes = [0, 1, 2]
-    field_data = TensorDict(
-        {
-            "prompt_text": ["Hello world!", "This is a longer sentence for testing", "Test case"],
-            "response_text": ["Hi there!", "This is the response to the longer sentence", "Test response"],
-        },
-        batch_size=[],
-    )
+    field_data = {
+        "prompt_text": ["Hello world!", "This is a longer sentence for testing", "Test case"],
+        "response_text": ["Hi there!", "This is the response to the longer sentence", "Test response"],
+    }
 
     response = client.send_put(0, local_indexes, field_data)
     assert response.request_type == ZMQRequestType.PUT_DATA_RESPONSE
@@ -347,14 +335,10 @@ def test_put_get_single_item(storage_setup):
     client = MockStorageClient(put_get_address)
 
     # PUT single item data
-    field_data = TensorDict(
-        {
-            "prompt_text": ["Hello world!"],
-            "attention_mask": [torch.tensor([1, 1, 1])],
-        },
-        batch_size=[],
-    )
-
+    field_data = {
+        "prompt_text": ["Hello world!"],
+        "attention_mask": [torch.tensor([1, 1, 1])],
+    }
     response = client.send_put(0, [0], field_data)
     assert response.request_type == ZMQRequestType.PUT_DATA_RESPONSE
 
@@ -363,11 +347,14 @@ def test_put_get_single_item(storage_setup):
     assert response.request_type == ZMQRequestType.GET_DATA_RESPONSE
 
     retrieved_data = response.body["data"]
+
+    print(retrieved_data)
+
     assert "prompt_text" in retrieved_data
     assert "attention_mask" in retrieved_data
 
     assert retrieved_data["prompt_text"][0] == "Hello world!"
-    assert retrieved_data["attention_mask"].shape == (1, 3)
+    assert len(retrieved_data["attention_mask"]) == 1
     torch.testing.assert_close(retrieved_data["attention_mask"][0], torch.tensor([1, 1, 1]))
 
     client.close()
@@ -381,13 +368,10 @@ def test_clear_data(storage_setup):
 
     # PUT data first
     local_indexes = [0, 1, 2]
-    field_data = TensorDict(
-        {
-            "log_probs": [torch.tensor([1.0]), torch.tensor([2.0]), torch.tensor([3.0])],
-            "rewards": [torch.tensor([10.0]), torch.tensor([20.0]), torch.tensor([30.0])],
-        },
-        batch_size=[],
-    )
+    field_data = {
+        "log_probs": [torch.tensor([1.0]), torch.tensor([2.0]), torch.tensor([3.0])],
+        "rewards": [torch.tensor([10.0]), torch.tensor([20.0]), torch.tensor([30.0])],
+    }
 
     response = client.send_put(0, local_indexes, field_data)
     assert response.request_type == ZMQRequestType.PUT_DATA_RESPONSE
@@ -395,7 +379,7 @@ def test_clear_data(storage_setup):
     # Verify data exists
     response = client.send_get(0, [0, 1, 2], ["log_probs"])
     assert response.request_type == ZMQRequestType.GET_DATA_RESPONSE
-    assert response.body["data"]["log_probs"].size(0) == 3
+    assert len(response.body["data"]["log_probs"]) == 3
 
     # Clear data
     response = client.send_clear(0, [0, 2])  # Clear only indexes 0 and 2
@@ -404,7 +388,7 @@ def test_clear_data(storage_setup):
     # Verify some data is cleared (but index 1 should still exist)
     response = client.send_get(0, [1], ["log_probs"])
     assert response.request_type == ZMQRequestType.GET_DATA_RESPONSE
-    assert response.body["data"]["log_probs"].size(0) == 1
+    assert len(response.body["data"]["log_probs"]) == 1
     torch.testing.assert_close(response.body["data"]["log_probs"][0], torch.tensor([2.0]))
 
     client.close()
@@ -417,25 +401,22 @@ def test_storage_unit_data_direct():
     storage_data = StorageUnitData(storage_size=10)
 
     # Test put_data
-    field_data = TensorDict(
-        {
-            "log_probs": [torch.tensor([1.0, 2.0]), torch.tensor([3.0, 4.0])],
-            "rewards": [torch.tensor([10.0]), torch.tensor([20.0])],
-        },
-        batch_size=[],
-    )
+    field_data = {
+        "log_probs": [torch.tensor([1.0, 2.0]), torch.tensor([3.0, 4.0])],
+        "rewards": [torch.tensor([10.0]), torch.tensor([20.0])],
+    }
     storage_data.put_data(field_data, [0, 1])
 
     # Test get_data
     result = storage_data.get_data(["log_probs", "rewards"], [0, 1])
     assert "log_probs" in result
     assert "rewards" in result
-    assert result["log_probs"].size(0) == 2
-    assert result["rewards"].size(0) == 2
+    assert len(result["log_probs"]) == 2
+    assert len(result["rewards"]) == 2
 
     # Test single index get
     result_single = storage_data.get_data(["log_probs"], [0])
-    assert result_single["log_probs"].shape == (1, 2)
+    assert torch.allclose(result_single["log_probs"][0], torch.tensor([1.0, 2.0]))
 
     # Test clear
     storage_data.clear([0])

--- a/tests/test_simple_storage_unit.py
+++ b/tests/test_simple_storage_unit.py
@@ -348,8 +348,6 @@ def test_put_get_single_item(storage_setup):
 
     retrieved_data = response.body["data"]
 
-    print(retrieved_data)
-
     assert "prompt_text" in retrieved_data
     assert "attention_mask" in retrieved_data
 

--- a/transfer_queue/storage/managers/simple_backend_manager.py
+++ b/transfer_queue/storage/managers/simple_backend_manager.py
@@ -28,6 +28,7 @@ from transfer_queue.metadata import BatchMeta
 from transfer_queue.storage.managers.base import TransferQueueStorageManager
 from transfer_queue.storage.managers.factory import TransferQueueStorageManagerFactory
 from transfer_queue.storage.simple_backend import StorageMetaGroup
+from transfer_queue.utils.utils import get_env_bool
 from transfer_queue.utils.zmq_utils import ZMQMessage, ZMQRequestType, ZMQServerInfo, create_zmq_socket
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,8 @@ if not logger.hasHandlers():
 
 TQ_SIMPLE_STORAGE_MANAGER_RECV_TIMEOUT = int(os.environ.get("TQ_SIMPLE_STORAGE_MANAGER_RECV_TIMEOUT", 200))  # seconds
 TQ_SIMPLE_STORAGE_MANAGER_SEND_TIMEOUT = int(os.environ.get("TQ_SIMPLE_STORAGE_MANAGER_SEND_TIMEOUT", 200))  # seconds
+
+TQ_ZERO_COPY_SERIALIZATION = get_env_bool("TQ_ZERO_COPY_SERIALIZATION", default=False)
 
 
 @TransferQueueStorageManagerFactory.register("AsyncSimpleStorageManager")
@@ -233,23 +236,11 @@ class AsyncSimpleStorageManager(TransferQueueStorageManager):
         Send data to a specific storage unit.
         """
 
-        tensordict_data = TensorDict(
-            {
-                field: (
-                    torch.nested.as_nested_tensor(storage_data[field])
-                    if storage_data[field] and all(isinstance(x, torch.Tensor) for x in storage_data[field])
-                    else NonTensorStack(*storage_data[field])
-                )
-                for field in storage_data.keys()
-            },
-            batch_size=len(local_indexes),
-        )
-
         request_msg = ZMQMessage.create(
             request_type=ZMQRequestType.PUT_DATA,
             sender_id=self.storage_manager_id,
             receiver_id=target_storage_unit,
-            body={"local_indexes": local_indexes, "data": tensordict_data},
+            body={"local_indexes": local_indexes, "data": storage_data},
         )
 
         try:
@@ -456,6 +447,11 @@ def _filter_storage_data(storage_meta_group: StorageMetaGroup, data: TensorDict)
         if not isinstance(result, tuple):
             result = (result,)
         results[fname] = list(result)
+
+        if not TQ_ZERO_COPY_SERIALIZATION:
+            # Explicitly copy tensor slices to prevent pickling the whole tensor for every storage unit.
+            # The tensors may still be continuous, so we cannot use .continuous() to trigger copy from parent tensors.
+            results[fname] = [item.clone() if isinstance(item, torch.Tensor) else item for item in results[fname]]
 
     return results
 

--- a/transfer_queue/storage/managers/simple_backend_manager.py
+++ b/transfer_queue/storage/managers/simple_backend_manager.py
@@ -28,7 +28,7 @@ from transfer_queue.metadata import BatchMeta
 from transfer_queue.storage.managers.base import TransferQueueStorageManager
 from transfer_queue.storage.managers.factory import TransferQueueStorageManagerFactory
 from transfer_queue.storage.simple_backend import StorageMetaGroup
-from transfer_queue.utils.utils import get_env_bool
+from transfer_queue.utils.serial_utils import zero_copy_serialization_enabled
 from transfer_queue.utils.zmq_utils import ZMQMessage, ZMQRequestType, ZMQServerInfo, create_zmq_socket
 
 logger = logging.getLogger(__name__)
@@ -42,8 +42,6 @@ if not logger.hasHandlers():
 
 TQ_SIMPLE_STORAGE_MANAGER_RECV_TIMEOUT = int(os.environ.get("TQ_SIMPLE_STORAGE_MANAGER_RECV_TIMEOUT", 200))  # seconds
 TQ_SIMPLE_STORAGE_MANAGER_SEND_TIMEOUT = int(os.environ.get("TQ_SIMPLE_STORAGE_MANAGER_SEND_TIMEOUT", 200))  # seconds
-
-TQ_ZERO_COPY_SERIALIZATION = get_env_bool("TQ_ZERO_COPY_SERIALIZATION", default=False)
 
 
 @TransferQueueStorageManagerFactory.register("AsyncSimpleStorageManager")
@@ -448,9 +446,9 @@ def _filter_storage_data(storage_meta_group: StorageMetaGroup, data: TensorDict)
             result = (result,)
         results[fname] = list(result)
 
-        if not TQ_ZERO_COPY_SERIALIZATION:
+        if not zero_copy_serialization_enabled():
             # Explicitly copy tensor slices to prevent pickling the whole tensor for every storage unit.
-            # The tensors may still be continuous, so we cannot use .continuous() to trigger copy from parent tensors.
+            # The tensors may still be contiguous, so we cannot use .contiguous() to trigger copy from parent tensors.
             results[fname] = [item.clone() if isinstance(item, torch.Tensor) else item for item in results[fname]]
 
     return results

--- a/transfer_queue/storage/simple_backend.py
+++ b/transfer_queue/storage/simple_backend.py
@@ -25,11 +25,10 @@ import ray
 import torch
 import zmq
 from ray.util import get_node_ip_address
-from tensordict import NonTensorStack, TensorDict
 
 from transfer_queue.metadata import SampleMeta
 from transfer_queue.utils.perf_utils import IntervalPerfMonitor
-from transfer_queue.utils.utils import TransferQueueRole, limit_pytorch_auto_parallel_threads
+from transfer_queue.utils.utils import TransferQueueRole, get_env_bool, limit_pytorch_auto_parallel_threads
 from transfer_queue.utils.zmq_utils import ZMQMessage, ZMQRequestType, ZMQServerInfo, create_zmq_socket, get_free_port
 
 logger = logging.getLogger(__name__)
@@ -43,6 +42,9 @@ if not logger.hasHandlers():
 
 TQ_STORAGE_POLLER_TIMEOUT = int(os.environ.get("TQ_STORAGE_POLLER_TIMEOUT", 5))  # in seconds
 TQ_NUM_THREADS = int(os.environ.get("TQ_NUM_THREADS", 8))
+
+
+TQ_ZERO_COPY_SERIALIZATION = get_env_bool("TQ_ZERO_COPY_SERIALIZATION", default=False)
 
 
 class StorageUnitData:
@@ -70,7 +72,7 @@ class StorageUnitData:
         # Maximum number of elements stored in storage unit
         self.storage_size = storage_size
 
-    def get_data(self, fields: list[str], local_indexes: list[int]) -> TensorDict[str, list]:
+    def get_data(self, fields: list[str], local_indexes: list[int]) -> dict[str, list]:
         """
         Get data from storage unit according to given fields and local_indexes.
 
@@ -79,7 +81,7 @@ class StorageUnitData:
             local_indexes: Local indexes used for getting data.
 
         Returns:
-            TensorDict with field names as keys, corresponding data list as values.
+            dict with field names as keys, corresponding data list as values.
         """
         result: dict[str, list] = {}
 
@@ -94,24 +96,17 @@ class StorageUnitData:
                 # The unsqueeze op make the shape from n to (1, n)
                 gathered_item = self.field_data[field][local_indexes[0]]
                 if not isinstance(gathered_item, torch.Tensor):
-                    result[field] = NonTensorStack(gathered_item)
+                    result[field] = gathered_item
                 else:
                     result[field] = gathered_item.unsqueeze(0)
             else:
                 gathered_items = list(itemgetter(*local_indexes)(self.field_data[field]))
 
-                if gathered_items:
-                    all_tensors = all(isinstance(x, torch.Tensor) for x in gathered_items)
-                    if all_tensors:
-                        result[field] = torch.nested.as_nested_tensor(gathered_items)
-                    else:
-                        result[field] = NonTensorStack(*gathered_items)
+                result[field] = gathered_items
 
-        # Explicit batch size for stability
-        batch_size = 0 if not fields or not local_indexes else len(local_indexes)
-        return TensorDict(result, batch_size=batch_size)
+        return result
 
-    def put_data(self, field_data: TensorDict[str, Any], local_indexes: list[int]) -> None:
+    def put_data(self, field_data: dict[str, Any], local_indexes: list[int]) -> None:
         """
         Put or update data into storage unit according to given field_data and local_indexes.
 
@@ -119,9 +114,8 @@ class StorageUnitData:
             field_data: Dict with field names as keys, corresponding data in the field as values.
             local_indexes: Local indexes used for putting data.
         """
-        extracted_data = field_data.to_dict()
 
-        for f, values in extracted_data.items():
+        for f, values in field_data.items():
             if f not in self.field_data:
                 self.field_data[f] = [None] * self.storage_size
 
@@ -132,7 +126,12 @@ class StorageUnitData:
                         f"storage_size: {self.storage_size}"
                     )
 
-                self.field_data[f][idx] = values[i]
+                if not TQ_ZERO_COPY_SERIALIZATION and isinstance(values[i], torch.Tensor):
+                    # Explicitly copy tensor slices to prevent pickling the whole tensor.
+                    # Get is more frequent, so we do the clone during put process.
+                    self.field_data[f][idx] = values[i].clone()
+                else:
+                    self.field_data[f][idx] = values[i]
 
     def clear(self, local_indexes: list[int]) -> None:
         """

--- a/transfer_queue/storage/simple_backend.py
+++ b/transfer_queue/storage/simple_backend.py
@@ -89,7 +89,6 @@ class StorageUnitData:
                 )
 
             if len(local_indexes) == 1:
-                # The unsqueeze op make the shape from n to (1, n)
                 gathered_item = self.field_data[field][local_indexes[0]]
                 result[field] = [gathered_item]
 

--- a/transfer_queue/storage/simple_backend.py
+++ b/transfer_queue/storage/simple_backend.py
@@ -95,10 +95,8 @@ class StorageUnitData:
             if len(local_indexes) == 1:
                 # The unsqueeze op make the shape from n to (1, n)
                 gathered_item = self.field_data[field][local_indexes[0]]
-                if not isinstance(gathered_item, torch.Tensor):
-                    result[field] = gathered_item
-                else:
-                    result[field] = gathered_item.unsqueeze(0)
+                result[field] = [gathered_item]
+
             else:
                 gathered_items = list(itemgetter(*local_indexes)(self.field_data[field]))
 

--- a/transfer_queue/storage/simple_backend.py
+++ b/transfer_queue/storage/simple_backend.py
@@ -22,13 +22,11 @@ from typing import Any
 from uuid import uuid4
 
 import ray
-import torch
 import zmq
 from ray.util import get_node_ip_address
 
 from transfer_queue.metadata import SampleMeta
 from transfer_queue.utils.perf_utils import IntervalPerfMonitor
-from transfer_queue.utils.serial_utils import zero_copy_serialization_enabled
 from transfer_queue.utils.utils import TransferQueueRole, limit_pytorch_auto_parallel_threads
 from transfer_queue.utils.zmq_utils import ZMQMessage, ZMQRequestType, ZMQServerInfo, create_zmq_socket, get_free_port
 
@@ -122,12 +120,7 @@ class StorageUnitData:
                         f"storage_size: {self.storage_size}"
                     )
 
-                if not zero_copy_serialization_enabled() and isinstance(values[i], torch.Tensor):
-                    # Explicitly copy tensor slices to prevent pickling the whole tensor.
-                    # Get is more frequent, so we do the clone during put process.
-                    self.field_data[f][idx] = values[i].clone()
-                else:
-                    self.field_data[f][idx] = values[i]
+                self.field_data[f][idx] = values[i]
 
     def clear(self, local_indexes: list[int]) -> None:
         """

--- a/transfer_queue/storage/simple_backend.py
+++ b/transfer_queue/storage/simple_backend.py
@@ -28,6 +28,7 @@ from ray.util import get_node_ip_address
 
 from transfer_queue.metadata import SampleMeta
 from transfer_queue.utils.perf_utils import IntervalPerfMonitor
+from transfer_queue.utils.serial_utils import zero_copy_serialization_enabled
 from transfer_queue.utils.utils import TransferQueueRole, get_env_bool, limit_pytorch_auto_parallel_threads
 from transfer_queue.utils.zmq_utils import ZMQMessage, ZMQRequestType, ZMQServerInfo, create_zmq_socket, get_free_port
 
@@ -124,7 +125,7 @@ class StorageUnitData:
                         f"storage_size: {self.storage_size}"
                     )
 
-                if not TQ_ZERO_COPY_SERIALIZATION and isinstance(values[i], torch.Tensor):
+                if not zero_copy_serialization_enabled() and isinstance(values[i], torch.Tensor):
                     # Explicitly copy tensor slices to prevent pickling the whole tensor.
                     # Get is more frequent, so we do the clone during put process.
                     self.field_data[f][idx] = values[i].clone()

--- a/transfer_queue/storage/simple_backend.py
+++ b/transfer_queue/storage/simple_backend.py
@@ -29,7 +29,7 @@ from ray.util import get_node_ip_address
 from transfer_queue.metadata import SampleMeta
 from transfer_queue.utils.perf_utils import IntervalPerfMonitor
 from transfer_queue.utils.serial_utils import zero_copy_serialization_enabled
-from transfer_queue.utils.utils import TransferQueueRole, get_env_bool, limit_pytorch_auto_parallel_threads
+from transfer_queue.utils.utils import TransferQueueRole, limit_pytorch_auto_parallel_threads
 from transfer_queue.utils.zmq_utils import ZMQMessage, ZMQRequestType, ZMQServerInfo, create_zmq_socket, get_free_port
 
 logger = logging.getLogger(__name__)
@@ -43,9 +43,6 @@ if not logger.hasHandlers():
 
 TQ_STORAGE_POLLER_TIMEOUT = int(os.environ.get("TQ_STORAGE_POLLER_TIMEOUT", 5))  # in seconds
 TQ_NUM_THREADS = int(os.environ.get("TQ_NUM_THREADS", 8))
-
-
-TQ_ZERO_COPY_SERIALIZATION = get_env_bool("TQ_ZERO_COPY_SERIALIZATION", default=False)
 
 
 class StorageUnitData:

--- a/transfer_queue/utils/serial_utils.py
+++ b/transfer_queue/utils/serial_utils.py
@@ -32,11 +32,18 @@ from torch.distributed.rpc.internal import _internal_rpc_pickler
 
 from transfer_queue.utils.utils import get_env_bool
 
+try:
+    from torch.distributed.rpc.internal import _internal_rpc_pickler
+
+    HAS_RPC_PICKLER = True
+except ImportError:
+    HAS_RPC_PICKLER = False
+
 CUSTOM_TYPE_PICKLE = 1
 CUSTOM_TYPE_CLOUDPICKLE = 2
 CUSTOM_TYPE_RAW_VIEW = 3
 
-TQ_ZERO_COPY_SERIALIZATION = get_env_bool("TQ_ZERO_COPY_SERIALIZATION", default=False)
+TQ_ZERO_COPY_SERIALIZATION = get_env_bool("TQ_ZERO_COPY_SERIALIZATION", default=False) and HAS_RPC_PICKLER
 
 bytestr: TypeAlias = bytes | bytearray | memoryview | zmq.Frame
 tensorenc = tuple[str, tuple[int, ...], int | memoryview]
@@ -269,3 +276,8 @@ def deserialization(data: list[bytestr] | bytestr) -> Any:
                 f"When TQ_ZERO_COPY_SERIALIZATION is disabled, input data should be a list of bytestr,"
                 f" but got {type(data)}."
             )
+
+
+def zero_copy_serialization_enabled() -> bool:
+    """Check if zero-copy serialization is enabled."""
+    return TQ_ZERO_COPY_SERIALIZATION

--- a/transfer_queue/utils/serial_utils.py
+++ b/transfer_queue/utils/serial_utils.py
@@ -28,21 +28,15 @@ import numpy as np
 import torch
 import zmq
 from msgspec import msgpack
+from torch.distributed.rpc.internal import _internal_rpc_pickler
 
 from transfer_queue.utils.utils import get_env_bool
-
-try:
-    from torch.distributed.rpc.internal import _internal_rpc_pickler
-
-    HAS_RPC_PICKLER = True
-except ImportError:
-    HAS_RPC_PICKLER = False
 
 CUSTOM_TYPE_PICKLE = 1
 CUSTOM_TYPE_CLOUDPICKLE = 2
 CUSTOM_TYPE_RAW_VIEW = 3
 
-TQ_ZERO_COPY_SERIALIZATION = get_env_bool("TQ_ZERO_COPY_SERIALIZATION", default=False) and HAS_RPC_PICKLER
+TQ_ZERO_COPY_SERIALIZATION = get_env_bool("TQ_ZERO_COPY_SERIALIZATION", default=False)
 
 bytestr: TypeAlias = bytes | bytearray | memoryview | zmq.Frame
 tensorenc = tuple[str, tuple[int, ...], int | memoryview]

--- a/transfer_queue/utils/serial_utils.py
+++ b/transfer_queue/utils/serial_utils.py
@@ -28,7 +28,6 @@ import numpy as np
 import torch
 import zmq
 from msgspec import msgpack
-from torch.distributed.rpc.internal import _internal_rpc_pickler
 
 from transfer_queue.utils.utils import get_env_bool
 


### PR DESCRIPTION
## Background

During real-world integration test with verl, we observe the TransferQueue introduces additional memory usage than expected.

<img width="2136" height="853" alt="image" src="https://github.com/user-attachments/assets/c7b2e03c-cef2-4db7-96ee-ea03f1d6a34d" />

During profiling (in branch [han/memory_profiling](https://github.com/TransferQueue/TransferQueue/tree/han/memory_profiling)), we thoroughly tack the memory usage and observe some improvements.

> Detailed blog for analyses can be found [here](https://www.yuque.com/haomingzi-lfse7/lhp4el/xc43dskkzzug0wlc?singleDoc#) (in Chinese).

## Problem Analyse

Assume the input data is 
```python3
input_ids = torch.randn(4096, 128000)

data_batch = TensorDict(
    {
        "input_ids": input_ids,
    },
    batch_size=input_ids.size(0),
)    # about 2GB
```
and we put this TensorDict into TQ with 4 storage units.



### Memory Doubling during Data Splitting

In `AsyncSimpleStorageManager.put_data()`, a data_batch (e.g., 2GB) is split into 4 parts.

- Issue: The splitting process constructs 4 new TensorDict objects.
- Root Cause: To handle these sub-batches, we currently utilize `torch.nested.as_nested_tensor`, which triggers a full memory copy.
- Impact: Memory usage jumps from 2GB to 4GB immediately during the split.

### Peak Memory during Serialization/Deserialization

When `TQ_ZERO_COPY_SERIALIZATION=False`:

- Put Path: Each coroutine processes ~0.5GB. pickle.dumps() allocates additional memory for serialized objects. Combined with the 4GB from Step 1, the client process peaks at ~6GB before falling back to 2GB after transmission.
- Get Path: During get_data(), the peak occurs when coroutines complete deserialization simultaneously, reaching 6GB before the intermediate buffers are cleared, falling back to 4GB.

### The "Parent Tensor" Serialization Corner Case

We observed that when `TQ_ZERO_COPY_SERIALIZATION=False`, retrieving a single sample from a storage unit could trigger a massive memory overhead.

- Root Cause: If the storage unit holds a slice of a larger tensor without a physical copy, pickle serializes the entire parent storage rather than just the slice.
- Impact: Requesting 1 sample results in the transmission and memory allocation of the entire storage unit's buffer. **This is a corner case since `torch.nested.as_nested_tensor` will not trigger memory copy when there is only 1 tensor.**



## Solution

### Transition from TensorDict to dict inside TransferQueue
We changed the internal data structure passed within TransferQueue from TensorDict to standard Python dict.

- Benefit: This bypasses the need for `torch.nested.as_nested_tensor`, effectively eliminating the 2GB -> 4GB memory copy during the splitting phase when `TQ_ZERO_COPY_SERIALIZATION=True`. For `TQ_ZERO_COPY_SERIALIZATION=False`, we manually trigger `.clone()` to make sure `pickle.dumps()` will not pickling the parent tensor.


Now the memory copy will be:

`TQ_ZERO_COPY_SERIALIZATION=True` (4 storage units):

1. **Client-side**: Prepare the tensor (0GB → 2GB).
2. **Client-side**: Split the tensor according to the number of storage units (2GB).
3. **Client-side**: Serialize the tensor and send it to each storage unit (2GB).
4. **Each storage unit**: Receive data (0GB → 0.5GB).
5. **Each storage unit**: Deserialize data, leading to peak memory usage (0.5GB → 1GB → 0.5GB).

`TQ_ZERO_COPY_SERIALIZATION=False` (4 storage units):

1. **Client-side**: Prepare the tensor (0GB → 2GB).
2. **Client-side**: Split the tensor according to the number of storage units, triggering a memory copy (2GB → 4GB).
3. **Client-side**: Serialize the tensor and send it to each storage unit (4GB → 6GB → 2GB).
4. **Each storage unit**: Receive data (0GB → 0.5GB).
5. **Each storage unit**: Deserialize data, leading to peak memory usage (0.5GB → 1GB → 0.5GB).

## Known Issues

### Memory Fragment in SimpleStorageUnit
<img width="1071" height="176" alt="image" src="https://github.com/user-attachments/assets/0bc668d3-13cd-4a7a-a859-3301c4243598" />

Since we eliminate the process of packing a new tensordict and treat each sample as individual tensor, the memory fragments will be more severe. However, there is no memory leaking so the memory can still be collected by system as needed.

<img width="1049" height="162" alt="image" src="https://github.com/user-attachments/assets/21d030ae-b58b-4f84-8f7c-db5642f9691e" />




CC @ji-huazhong @jianjunzhong @dpj135 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TQ_ZERO_COPY_SERIALIZATION environment variable to control serialization behavior in storage operations.

* **Bug Fixes**
  * Improved data handling in storage operations to prevent unintended shared references during serialization when zero-copy mode is disabled.

* **Tests**
  * Updated test suite to reflect storage data handling changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->