### PR TITLE
[Feat] Introduce Zero-Copy to use YuanrongStorageClient for transmitting CPU Tensors

### DIFF
--- a/tests/test_ds_zero_copy.py
+++ b/tests/test_ds_zero_copy.py
@@ -35,7 +35,7 @@ class WriterActor:
 
     def generate_data(
         self, partition_id, batch_size: int = 10000, seq_len: int = 10000
-    ) 
+    ): 
         data = TensorDict(
             {
                 "input_ids": torch.randn(batch_size, seq_len, dtype=torch.float32),
@@ -47,7 +47,7 @@ class WriterActor:
         print(f"Generated data of size {size:.2f} MB")
         self.data = data
 
-    def put_once(self, partition_id)
+    def put_once(self, partition_id):
         t0 = time.perf_counter()
         batch_meta = self.client.put(data=self.data, partition_id=partition_id)
         return time.perf_counter() - t0, batch_meta

--- a/tests/test_ds_zero_copy.py
+++ b/tests/test_ds_zero_copy.py
@@ -1,0 +1,133 @@
+import sys
+import time
+from pathlib import Path
+
+import ray
+import torch
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+from tensordict import TensorDict
+
+parent_dir = Path(__file__).resolve().parent.parent
+sys.path.append(str(parent_dir))
+
+from transfer_queue.client import TransferQueueClient  # noqa: E402
+from transfer_queue.metadata import BatchMeta, FieldMeta, SampleMeta  # noqa: E402
+from transfer_queue.storage.managers.yuanrong_manager import YuanrongStorageManager  # noqa: E402
+from transfer_queue.storage.clients.yuanrong_client import YuanrongStorageClient  # noqa: E402
+from transfer_queue.storage.managers.factory import TransferQueueStorageManagerFactory  # noqa: E402
+from transfer_queue.utils.zmq_utils import ZMQServerInfo  # noqa: E402
+from transfer_queue import (
+    TransferQueueController,
+    process_zmq_server_info,    
+)
+
+def tensordict_memory_mb(td):
+    total_bytes = sum(tensor.element_size() * tensor.numel() for tensor in td.values())
+    return total_bytes / (1024 * 1024)
+
+@ray.remote
+class WriterActor:
+    def __init__(self, controller_info, config):
+
+        self.client = TransferQueueClient(client_id=f"writer_{id(self)}", controller_info=controller_info)
+        self.client.initialize_storage_manager("YuanrongStorageManager", config)
+        self.data = None
+
+    def generate_data(
+        self, partition_id, batch_size: int = 10000, seq_len: int = 10000
+    ) 
+        data = TensorDict(
+            {
+                "input_ids": torch.randn(batch_size, seq_len, dtype=torch.float32),
+            },
+            batch_size=batch_size,
+        )
+
+        size = tensordict_memory_mb(data)
+        print(f"Generated data of size {size:.2f} MB")
+        self.data = data
+
+    def put_once(self, partition_id)
+        t0 = time.perf_counter()
+        batch_meta = self.client.put(data=self.data, partition_id=partition_id)
+        return time.perf_counter() - t0, batch_meta
+
+
+@ray.remote
+class ReaderActor:
+    def __init__(self, controller_info, config):
+
+        self.client = TransferQueueClient(client_id=f"reader_{id(self)}", controller_info=controller_info)
+        self.client.initialize_storage_manager("YuanrongStorageManager", config)
+
+    def get_once(self, metadata: BatchMeta):
+        t0 = time.perf_counter()
+        self.client.get_data(metadata)
+        return time.perf_counter() - t0
+
+def main():
+    if not ray.is_initialized():
+        ray.init(address="auto")
+
+    data_system_controller = TransferQueueController.remote()
+    controller_info = process_zmq_server_info(data_system_controller)
+
+    config_writer = {
+        "client_name": "YuanrongStorageClient",
+        "controller_info": controller_info,
+        "host": "10.90.41.116",
+        "port": 36666,
+    }
+
+    config_reader = {
+        "client_name": "YuanrongStorageClient",
+        "controller_info": controller_info,
+        "host": "10.90.41.117",
+        "port": 36666,
+    }
+
+    nodes = ray.nodes()
+    ip_to_nodeid = {}
+    for n in nodes:
+        addr = n.get("NodeManagerAddress") or n.get("node_ip_address") or n.get("NodeIP")
+        node_id = n["NodeID"] if "NodeID" in n else n.get("NodeID") or n.get("node_id")
+        if addr and node_id:
+            ip_to_nodeid[addr] = node_id
+
+    ip_A = "10.90.41.117"  # Writer
+    ip_B = "10.90.41.116"  # Reader
+    node_id_A = ip_to_nodeid.get(ip_A)
+    node_id_B = ip_to_nodeid.get(ip_B)
+    assert node_id_A and node_id_B, f"cannot find node ids for {ip_A}, {ip_B}: {ip_to_nodeid}"
+
+    writer = WriterActor.options(
+        scheduling_strategy=NodeAffinitySchedulingStrategy(node_id=node_id_A, soft=False),
+    ).remote(controller_info, config_writer)
+    reader = ReaderActor.options(
+        scheduling_strategy=NodeAffinitySchedulingStrategy(node_id=node_id_B, soft=False),
+    ).remote(controller_info, config_reader)
+
+    batch_metas = []
+    put_times = []
+    get_times =[]
+
+    for i in range(3):
+        partition_id = f"train_step_{i}"
+        ray.get(writer.generate_data.remote(batch_size=512, seq_len=32 * 1024))
+        cost, batch_meta = ray.get(writer.put_once.remote(partition_id))
+        print(f"[WriterActor] The time consumed by the {i}th put costs: {cost:.2f}s")
+        batch_metas.append(batch_meta)
+        put_times.append(cost)
+
+    for i, meta in enumerate(batch_metas):
+        cost = ray.get(reader.get_once.remote(meta))
+        get_times.append(cost)
+        print(f"[ReaderActor] The time consumed by the {i}th get costs: {cost:.2f}s")
+
+    avg_put_time = sum(put_times) / len(put_times)
+    avg_get_time = sum(get_times) / len(get_times)
+    print(f"Average put time: {avg_put_time:.2f}s")
+    print(f"Average get time: {avg_get_time:.2f}s")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ds_zero_copy.py
+++ b/tests/test_ds_zero_copy.py
@@ -16,7 +16,7 @@ from transfer_queue.storage.managers.yuanrong_manager import YuanrongStorageMana
 from transfer_queue.storage.clients.yuanrong_client import YuanrongStorageClient  # noqa: E402
 from transfer_queue.storage.managers.factory import TransferQueueStorageManagerFactory  # noqa: E402
 from transfer_queue.utils.zmq_utils import ZMQServerInfo  # noqa: E402
-from transfer_queue import (
+from transfer_queue import ( #noqa: E402
     TransferQueueController,
     process_zmq_server_info,    
 )
@@ -40,7 +40,7 @@ class WriterActor:
             {
                 "input_ids": torch.randn(batch_size, seq_len, dtype=torch.float32),
             },
-            batch_size=batch_size,
+            batch_size=batch_size
         )
 
         size = tensordict_memory_mb(data)
@@ -76,14 +76,14 @@ def main():
         "client_name": "YuanrongStorageClient",
         "controller_info": controller_info,
         "host": "10.90.41.116",
-        "port": 36666,
+        "port": 36666
     }
 
     config_reader = {
         "client_name": "YuanrongStorageClient",
         "controller_info": controller_info,
         "host": "10.90.41.117",
-        "port": 36666,
+        "port": 36666
     }
 
     nodes = ray.nodes()
@@ -94,8 +94,8 @@ def main():
         if addr and node_id:
             ip_to_nodeid[addr] = node_id
 
-    ip_A = "10.90.41.117"  # Writer
-    ip_B = "10.90.41.116"  # Reader
+    ip_A = "10.90.41.116"  # Writer
+    ip_B = "10.90.41.117"  # Reader
     node_id_A = ip_to_nodeid.get(ip_A)
     node_id_B = ip_to_nodeid.get(ip_B)
     assert node_id_A and node_id_B, f"cannot find node ids for {ip_A}, {ip_B}: {ip_to_nodeid}"

--- a/transfer_queue/storage/clients/yuanrong_client.py
+++ b/transfer_queue/storage/clients/yuanrong_client.py
@@ -64,7 +64,7 @@ def unpack_from(source):
     item_count = struct.unpack_from(HEADER_FMT, mv, 0)[0]
     offsets = []
     for i in range(item_count):
-        offset, length - struct.unpack_from(ENTRY_FMT, mv, HEADER_SIZE + i * ENTRY_SIZE)
+        offset, length = struct.unpack_from(ENTRY_FMT, mv, HEADER_SIZE + i * ENTRY_SIZE)
         offsets.append((offset, length))
     return [mv[offset: offset + length] for offset, length in offsets]
 
@@ -336,7 +336,7 @@ class YuanrongStorageClient(TransferQueueStorageKVClient):
                     raise ValueError(f"Size mismatch for key {key[i]}: got {len(raw_val)}, expected {expected_size}")
                 
                 arr = np.frombuffer(raw_val, dtype=numpy_dtype).reshape(shape)
-                result[i] = torch.from_numpy(arr)
+                results[i] = torch.from_numpy(arr)
 
         return results
 

--- a/transfer_queue/storage/clients/yuanrong_client.py
+++ b/transfer_queue/storage/clients/yuanrong_client.py
@@ -16,10 +16,13 @@
 import logging
 import os
 import pickle
+import struct
+import ctypes
 from typing import Any
 
 import torch
 from torch import Tensor
+from concurrent.futures import ThreadPoolExecutor
 
 from transfer_queue.storage.clients.base import TransferQueueStorageKVClient
 from transfer_queue.storage.clients.factory import StorageClientFactory

--- a/transfer_queue/storage/clients/yuanrong_client.py
+++ b/transfer_queue/storage/clients/yuanrong_client.py
@@ -23,6 +23,7 @@ from typing import Any
 import torch
 from torch import Tensor
 from concurrent.futures import ThreadPoolExecutor
+import numpy as np
 
 from transfer_queue.storage.clients.base import TransferQueueStorageKVClient
 from transfer_queue.storage.clients.factory import StorageClientFactory
@@ -218,7 +219,7 @@ class YuanrongStorageClient(TransferQueueStorageKVClient):
             #  All data goes through CPU path
             for i in range(0, len(keys), CPU_DS_CLIENT_KEYS_LIMIT):
                 batch_keys = keys[i : i + CPU_DS_CLIENT_KEYS_LIMIT]
-                batch_vals = pickled_values[i : i + CPU_DS_CLIENT_KEYS_LIMIT]
+                batch_vals = values[i : i + CPU_DS_CLIENT_KEYS_LIMIT]
                 self.mset_zcopy(batch_keys, batch_vals)
 
     def put(self, keys: list[str], values: list[Any]):

--- a/transfer_queue/storage/clients/yuanrong_client.py
+++ b/transfer_queue/storage/clients/yuanrong_client.py
@@ -36,6 +36,55 @@ try:
 except ImportError:
     YUANRONG_DATASYSTEM_IMPORTED = False
 
+HEADER_FMT = "<I"
+HEADER_SIZE = struct.calcsize(HEADER_FMT)
+ENTRY_FMT = "<II"
+ENTRY_SIZE = struct.calcsize(ENTRY_FMT)
+
+def calc_packed_size(items):
+    return HEADER_SIZE + len(items) * ENTRY_SIZE + sum(item.nbytes for item in items)
+
+def pack_into(target, items):
+    struct.pack_into(HEADER_FMT, target, 0, len(items))
+
+    entry_offset = HEADER_SIZE
+    payload_offset = HEADER_SIZE + len(items) * ENTRY_SIZE
+
+    target_tensor = torch.frombuffer(target, dtype=torch.uint8)
+
+    for item in items:
+        struct.pack_into(ENTRY_FMT, target, entry_offset, payload_offset, item.nbytes)
+        src_tensor = torch.frombuffer(item, dtype=torch.uint8)
+        target_tensor[payload_offset: payload_offset + item.nbytes].copy_(src_tensor)
+        entry_offset += ENTRY_SIZE
+        payload_offset += item.nbytes
+
+def unpack_from(source):
+    mv = memoryview(source)
+    item_count = struct.unpack_from(HEADER_FMT, mv, 0)[0]
+    offsets = []
+    for i in range(item_count):
+        offset, length - struct.unpack_from(ENTRY_FMT, mv, HEADER_SIZE + i * ENTRY_SIZE)
+        offsets.append((offset, length))
+    return [mv[offset: offset + length] for offset, length in offsets]
+
+def try_zero_copy_serialize(obj: Any) -> memoryview | bytes | bytearray:
+    """
+    Attempts to serialize an object using zero-copy if possible.
+    If the object supports the buffer protocol (like numpy arrays or contiguous tensors),
+    it returns a memoryview for zero-copy serialization. Otherwise, it falls back to
+    standard pickle serialization.
+    Args:
+        obj (Any): The object to serialize.
+    Returns:
+        Union[memoryview, bytes, bytearray]: The serialized object.
+    """
+    if isinstance(obj, torch.Tensor) and obj.is_contiguous():
+        return memoryview(obj.numpy())
+    try:
+        return memoryview(obj)
+    except TypeError:
+        return pickle.dumps(obj)
 
 @StorageClientFactory.register("YuanrongStorageClient")
 class YuanrongStorageClient(TransferQueueStorageKVClient):
@@ -104,6 +153,17 @@ class YuanrongStorageClient(TransferQueueStorageKVClient):
             tensors.append(tensor)
         return tensors
 
+    def mset_zcopy(self, keys: list[str], objs: list[Any]):
+        serialized = [try_zero_copy_serialize(obj) for obj in objs]
+        items_list = [[item] for item in serialized]
+        packed_sizes = [calc_packed_size(items) for items in items_list]
+        status, buffers = self._cpu_ds_client.mcreate(keys, packed_sizes)
+        max_workers = min(32, (os.cpu_count() or 1) * 2)
+        tasks = [(target.mutable_data(), item) for target, item in zip(buffers, items_list)]
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            list(executor.map(lambda p: pack_into(*p), tasks))
+        self._cpu_ds_client.mset_zero_copy(buffers)
+
     def _batch_put(self, keys: list[str], values: list[Any]):
         """Stores a batch of key-value pairs to remote storage, splitting by device type.
 
@@ -153,11 +213,10 @@ class YuanrongStorageClient(TransferQueueStorageKVClient):
 
         else:
             #  All data goes through CPU path
-            pickled_values = [pickle.dumps(v) for v in values]
             for i in range(0, len(keys), CPU_DS_CLIENT_KEYS_LIMIT):
                 batch_keys = keys[i : i + CPU_DS_CLIENT_KEYS_LIMIT]
                 batch_vals = pickled_values[i : i + CPU_DS_CLIENT_KEYS_LIMIT]
-                self._cpu_ds_client.mset(batch_keys, batch_vals)
+                self.mset_zcopy(batch_keys, batch_vals)
 
     def put(self, keys: list[str], values: list[Any]):
         """Stores multiple key-value pairs to remote storage.
@@ -248,6 +307,38 @@ class YuanrongStorageClient(TransferQueueStorageKVClient):
                     results[idx] = pickle.loads(raw_val)
 
             return results
+
+        else:
+            results = [None] * len(keys)
+            status, buffers = self._cpu_ds_client.mget(keys, timeout_ms=500)
+            for i, (buffer, shape, dtype) in enumerate(zip(buffers, shapes, dtypes)):
+                if buffer is None:
+                    continue
+                try:
+                    # it is assumed that each key corresponds to only one tensor
+                    # so after unpacking, take `unpacked_buffers[0]`
+                    unpacked_buffers = unpack_from(buffer) # list of memoryview
+                except Exception as e:
+                    logger.warning(f"Failed to unpack buffer for key {keys[i]}: {e}")
+                    continue
+                
+                if len(unpacked_buffers) != 1:
+                    # if each key corresponds to multiple tensors, more complex logic is required here
+                    raise ValueError(f"Expected 1 tensor per key, got {len(unpacked_buffers)} for key {keys[i]}")
+                
+                raw_val = unpacked_buffers[0]
+
+                numpy_dtype = torch.empty((), dtype=dtype).numpy().dtype
+                total_elements = int(np.prod(shape))
+                expected_size = total_elements * np.dtype(numpy_dtype).itemsize
+
+                if len(raw_val) != expected_size:
+                    raise ValueError(f"Size mismatch for key {key[i]}: got {len(raw_val)}, expected {expected_size}")
+                
+                arr = np.frombuffer(raw_val, dtype=numpy_dtype).reshape(shape)
+                result[i] = torch.from_numpy(arr)
+
+        return results
 
     def get(self, keys: list[str], shapes=None, dtypes=None) -> list[Any]:
         """Retrieves multiple values from remote storage with expected metadata.


### PR DESCRIPTION
### Summary

When connecting to the backend of the YuanrongStorageClient, zero-copy is activated to enhance the transmission speed.

### Change

1. Modified the `transfer_queue/storage/clients/yuanrong_client.py` to call the zero-copy interface, and performed operations such as serialization and pack.

2. Add p2p tests: `tests/test_ds_zero_copy.py` .

### Testing

- Test on CPU:

  `python tests/test_ds_zero_copy.py `

### Result

When transmitting 512 pieces of data, each 32 MB in size, with a total data volume of 16GB:
End-to-end **Get** took **10s** and the bandwidth was **1.6 GB/s**. The time spent calling the **YuanrongStorageClient** interface was **2.27s** with a bandwidth of **7.05 GB/s**.
End-to-end **Put** took **3.42s** and the bandwidth was **4.68 GB/s**. The time spent calling the **YuanrongStorageClient** interface was **3.32s** with a bandwidth of **4.83 GB/s**.

### Related Links

- Previous issues can be viewed: [[Feat]: Try zero-copy serialize objects that can be converted to memoryview](https://github.com/TransferQueue/TransferQueue/pull/147)

- Yuanrong Datasystem PR: [https://atomgit.com/openeuler/yuanrong-datasystem/pull/141](https://atomgit.com/openeuler/yuanrong-datasystem/pull/141)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added zero-copy packed-buffer support for more efficient tensor storage and retrieval on CPU, with contiguous-buffer serialization, robust unpacking, and fallbacks for non-accelerated environments.

* **Tests**
  * Added a distributed Ray-based benchmark that measures zero-copy transfer performance, per-operation timing, and end-to-end throughput across multiple partitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->